### PR TITLE
docs: add PBI-002..009 roadmap from v0.0.1 code review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# PBI index
+
+| PBI | Title | Status | Notes |
+|---|---|---|---|
+| [001](./pbi-001-copy-as-json.md) | Copy variable as JSON during C# debugging | Implemented in `v0.0.1`, awaiting UAT | The original feature. |
+| [002](./pbi-002-validate-evaluate-result.md) | Validate evaluate result before clipboard write | Proposed | Closes review item C1; depends on nothing. |
+| [003](./pbi-003-stable-capability-detection.md) | Stable detection of `supportsClipboardContext` | Proposed | Closes review item C3; depends on nothing. |
+| [004](./pbi-004-frame-stability-across-dialogs.md) | Re-validate stack frame after the side-effect warning | Proposed | Closes review item C2; depends on nothing. |
+| [005](./pbi-005-activation-integration-tests.md) | `@vscode/test-electron` harness | Proposed | Foundational; unblocks automated AC for PBI-002/003/004. |
+| [006](./pbi-006-ux-and-edge-case-polish.md) | UX polish and edge-case messaging | Proposed | Bundles R2 / R3 / R4 / S1. |
+| [007](./pbi-007-workflow-supply-chain-hardening.md) | Workflow and supply-chain hardening | Proposed | SHA-pin actions, scope perms, enforce zero runtime deps. |
+| [008](./pbi-008-type-checked-eslint.md) | Adopt type-checked ESLint preset | Proposed | Lint upgrade; depends on PBI-005 only if you want lint failures to block CI on test files. |
+| [009](./pbi-009-marketplace-publish-prep.md) | Marketplace publish prep (`0.1.0`) | Proposed | Should land **after** 002/003/004 and 005. |
+
+## Suggested order of work
+
+1. **PBI-005** first - the test harness unblocks credible acceptance criteria for the rest.
+2. **PBI-002**, **PBI-003**, **PBI-004** in parallel - the three criticals; small, independent.
+3. **PBI-007** and **PBI-008** in parallel - infrastructure work that has no user-visible risk.
+4. **PBI-006** - UX polish, batches well with whichever of 002/003/004 lands last.
+5. **PBI-009** - the publish-prep PBI; should be the last one merged before tagging `v0.1.0`.

--- a/docs/pbi-002-validate-evaluate-result.md
+++ b/docs/pbi-002-validate-evaluate-result.md
@@ -1,0 +1,51 @@
+# PBI-002: Validate evaluate result before clipboard write
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (criticals C1, R1, R5).
+
+## Goal
+
+Ensure that what we put on the clipboard is actually a serialized JSON document, not a truncated debug-adapter `toString`, an error message phrased like a value, or a `repl` decoration. Today the extension trusts the first non-empty `evaluate.result` per context and then runs it through a C# unescaper. If a hover-context evaluate returns the truncated form `"{ Name = ..."`, we cheerfully unescape and copy garbage.
+
+## Scope
+
+In:
+
+- After every `evaluate` attempt, run the unescaped string through `JSON.parse` and reject the result if it does not parse.
+- On `repl` context responses, strip the leading echo decoration produced by some adapters before validating.
+- Tighten `looksLikeError` so it does not false-positive on serialized strings that happen to contain the word "exception" (e.g. `{"Name":"NullReferenceException sample"}`).
+- When all contexts return parse-failures, surface the original `result` (truncated to N chars) in the error toast and full payload to the trace channel.
+
+Out:
+
+- Adapter-side fixes for truncation. We do client-side validation only.
+- Falling back to `variablesReference` traversal for over-budget objects (tracked in PBI-001 follow-ups).
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| `JSON.parse` is the validator (not regex) | The unescaped output is exactly meant to be JSON; if it does not parse, it is wrong. |
+| Validate after unescape, not before | C# string literal escapes are not legal JSON; we must unescape first. |
+| Treat parse failure as a context failure, not a hard error | We still want to fall through `clipboard -> hover -> repl` and try Newtonsoft. |
+
+## Acceptance criteria
+
+- A truncated hover-context response no longer reaches the clipboard. Either the next context succeeds or the user sees a `Could not serialize: response was truncated by the debug adapter` toast.
+- `looksLikeError` returns `false` for valid JSON whose contents happen to contain the substrings `error` / `exception`.
+- Unit tests cover: `JSON.parse` happy path, parse-failure rejection, `repl` echo stripping, false-positive `looksLikeError` regression.
+- Manual UAT: scenario 1 from PBI-001 still passes; a deliberately truncated value (e.g. `trap.Slow` mid-evaluation) shows the truncation toast.
+
+## UAT checklist
+
+| # | Variable / scenario | Expected result |
+|---|---|---|
+| 1 | `person` | Indented JSON, identical to PBI-001 #1. |
+| 2 | A large object whose serialized form exceeds the hover-context budget | Either Newtonsoft path succeeds or truncation toast appears; clipboard is never set to the truncated string. |
+| 3 | `{"Name":"NullReferenceException sample"}` synthesized via the immediate window | JSON written to clipboard; not flagged as an error. |
+| 4 | Forced `JSON.parse` failure (mock) | Trace channel logs full payload; user-facing toast is one line. |
+
+## Telemetry
+
+None.

--- a/docs/pbi-003-stable-capability-detection.md
+++ b/docs/pbi-003-stable-capability-detection.md
@@ -1,0 +1,52 @@
+# PBI-003: Stable detection of `supportsClipboardContext`
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (critical C3).
+
+## Goal
+
+Stop relying on the duck-typed `(session as any).capabilities.supportsClipboardContext` access. The `capabilities` field is not part of `vscode.DebugSession`'s public API; it happens to exist on the current implementation. A future VS Code release that hides the field will silently demote every user to the `hover -> repl` path and re-introduce the truncation bug PBI-002 is fixing.
+
+## Scope
+
+In:
+
+- Replace the cast with a public mechanism. Two acceptable options:
+  1. Probe-then-fallback: try `evaluate` with `context: 'clipboard'` first, and on `Capability not supported` / `unrecognized context` errors fall through to `hover`.
+  2. `vscode.debug.registerDebugAdapterTrackerFactory` to read `InitializeResponse.body.supportsClipboardContext` from the wire.
+- Cache the resolved capability per session (keyed by `session.id`) to avoid paying the probe cost on every invocation.
+- Invalidate the cache on `onDidTerminateDebugSession`.
+
+Out:
+
+- Removing the `clipboard` context entirely. We still want it when supported.
+- Reworking the rest of the context fallback chain (covered by PBI-002).
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| Prefer the tracker over probe-and-fallback | One round trip cheaper, and the answer is authoritative. |
+| Per-session cache, not per-extension | The user can have multiple debug sessions with different adapters; a global cache would be wrong. |
+| Keep `clipboard` as the first preference when supported | Mirrors VS Code's built-in "Copy Value" behavior (decision carried over from PBI-001). |
+
+## Acceptance criteria
+
+- No `as any` casts on `vscode.DebugSession` anywhere in `extension.ts`.
+- Manual run on VS Code 1.89, current stable, and current insiders: clipboard context is chosen exactly when the adapter advertises it.
+- Killing the extension's tracker (or running against an adapter that never sends `supportsClipboardContext`) results in `hover -> repl` being attempted, not a crash.
+- Unit / integration test asserts that a session whose tracker received `supportsClipboardContext: false` does not attempt a `clipboard` evaluate.
+
+## UAT checklist
+
+| # | Scenario | Expected result |
+|---|---|---|
+| 1 | C# debug session, `coreclr`, default adapter | Trace logs show `clipboard` attempted first. |
+| 2 | C# debug session against an adapter forced to omit `supportsClipboardContext` | Trace logs show first attempt is `hover`; clipboard is never tried. |
+| 3 | Two concurrent sessions with different capabilities | Each respects its own cached value. |
+| 4 | Restart VS Code, start a fresh session | Cache is empty; capability is resolved on first invocation. |
+
+## Telemetry
+
+None.

--- a/docs/pbi-004-frame-stability-across-dialogs.md
+++ b/docs/pbi-004-frame-stability-across-dialogs.md
@@ -1,0 +1,51 @@
+# PBI-004: Re-validate stack frame after the side-effect warning
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (critical C2).
+
+## Goal
+
+Today the side-effect warning is shown synchronously before the `evaluate` is dispatched, but the `frameId` is captured *before* the warning. If the user clicks Continue (or Step) during the dialog, by the time we evaluate, the frame is stale and the adapter returns an opaque error. We want the user to see a clean "session moved" message and not a confusing adapter dump.
+
+## Scope
+
+In:
+
+- Show the side-effect warning *before* resolving the active stack frame on first run.
+- After the user dismisses the warning, re-read `vscode.debug.activeStackItem` and `vscode.debug.activeDebugSession`. If either has changed (or is undefined), abort with a single-line toast: `Active debug session changed; please re-trigger Copy as JSON.`
+- On every subsequent invocation, capture `{sessionId, frameId, threadId}` immediately before each evaluate and re-check after each `await` boundary in the fallback chain. If the trio changes mid-flight, abort with the same message.
+- Cancel any in-flight evaluate via `customRequest('cancel', ...)` when the session changes (best effort; tolerate `Cancellation not supported`).
+
+Out:
+
+- Re-running the operation automatically on the new frame (would require the user's intent to change; not in scope).
+- Suppressing the warning entirely (already handled by the "Don't show again" path).
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| Re-validate after every `await` | The user can step at any point. Validating only at the start would still race. |
+| Single error string for all "session moved" cases | Easier to test and to match in the existing concurrency-guard test. |
+| Best-effort cancel, do not block on it | Not all adapters support `cancel`; we already swallow its errors elsewhere. |
+
+## Acceptance criteria
+
+- Pressing **Continue** while the side-effect warning is showing produces the "session moved" toast, not an adapter error trace.
+- Pressing **Step Over** between the `clipboard` and `hover` attempts in a deliberately slow scenario produces the same toast.
+- The existing concurrency-guard test in PBI-001 still passes.
+- Trace channel records the captured `{sessionId, frameId}` on capture and on each re-validation.
+
+## UAT checklist
+
+| # | Scenario | Expected result |
+|---|---|---|
+| 1 | First-ever invocation; click Continue while the warning is up | "Session moved" toast; clipboard unchanged. |
+| 2 | Slow `evaluate`; user steps once between attempts | Same toast; no clipboard write. |
+| 3 | Switch active session to a second `coreclr` session before triggering | Same toast (covers PBI-001 UAT #7). |
+| 4 | Normal happy path (no stepping) | Behaves exactly as PBI-001 #1. |
+
+## Telemetry
+
+None.

--- a/docs/pbi-005-activation-integration-tests.md
+++ b/docs/pbi-005-activation-integration-tests.md
@@ -1,0 +1,51 @@
+# PBI-005: Activation and integration test harness via `@vscode/test-electron`
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (test-coverage gap T1, prerequisite for PBI-002/003/004 acceptance tests).
+
+## Goal
+
+Today the test suite covers the two pure utility modules (`expression`, `unescape`) and nothing else. There is no test that the extension activates, that the command is registered under the right `when` clauses, or that a synthetic debug session triggers the code path. We want a thin but real `@vscode/test-electron` harness so that PBI-002/003/004 can land with regression tests instead of just manual UAT.
+
+## Scope
+
+In:
+
+- Add `@vscode/test-electron` and a `runTests` entry point.
+- Activation smoke test: load the extension in a downloaded VS Code, assert `csharpDebugCopyAsJson.copy` is in the command palette result.
+- `withTimeout` test (currently un-covered) using fake timers.
+- `looksLikeError` test (regression coverage for PBI-002).
+- A fake `DebugAdapter` (in-process) that:
+  - advertises `supportsClipboardContext`,
+  - returns canned `evaluate` responses,
+  - is enough to drive the success and the "all contexts failed" paths end-to-end.
+- Wire the new test entry into `npm test` and CI.
+
+Out:
+
+- A real `coreclr` adapter under CI. Too heavy and platform-dependent.
+- Cross-platform matrix (Linux Electron only is fine for now).
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| `@vscode/test-electron`, not `@vscode/test-cli` | The extension targets the legacy `--ui tdd` Mocha runner (carried from PBI-001). Switching test runners is out of scope. |
+| In-process fake adapter | A real `coreclr` launch would balloon CI time and leak platform-specific issues into the test signal. |
+| Only Linux electron in CI | Cheapest signal; the extension is JS, not native. |
+
+## Acceptance criteria
+
+- `npm test` runs both the existing unit tests and the new electron-based integration tests locally.
+- CI runs the electron tests in a headless Linux job and they pass.
+- Coverage report (text summary, no upload) shows non-zero coverage for `extension.ts`.
+- PBI-002, PBI-003, PBI-004 can express their acceptance criteria as automated tests in this harness.
+
+## UAT checklist
+
+Not user-facing; covered by green CI.
+
+## Telemetry
+
+None.

--- a/docs/pbi-006-ux-and-edge-case-polish.md
+++ b/docs/pbi-006-ux-and-edge-case-polish.md
@@ -1,0 +1,54 @@
+# PBI-006: UX polish and edge-case messaging
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (R2, R3, R4, S1).
+
+## Goal
+
+Tighten the user-facing strings and recover from a handful of edge cases gracefully. Individually small; together they remove most of the "what just happened?" moments in the current build.
+
+## Scope
+
+In:
+
+- **R2 / "View Logs" without trace.** Either always log errors (sanitized: command, target shape, last-context attempted, error message) so the **View Logs** button is always useful, or hide the button when `csharpDebugCopyAsJson.trace` is `false`.
+- **R3 / Ref-struct refusal.** When `variable.type` matches `^(System\.)?(Span|ReadOnlySpan|Memory|ReadOnlyMemory|Utf8JsonReader|Utf8JsonWriter)<`, refuse with a clear message ("Cannot serialize ref-struct types") instead of issuing an evaluate that the JIT will reject.
+- **R4 / Side-effect dialog wording.** Re-word the buttons so they are not redundant. Proposed: **OK** + **Don't show again**. Also stop showing the dialog at all when the active session was launched with `noDebug: true` (we are not actually pausing for them).
+- **S1 / Codicon.** Change the menu icon from `$(clippy)` to `$(copy)` (Clippy is unsanctioned in the contrib guidelines).
+- Centralize all user-facing strings in a `messages.ts` constant map so that the existing tests can assert on them without hard-coding strings in the producer.
+
+Out:
+
+- Localization (`l10n`) wiring; would be nice but is its own PBI.
+- New telemetry. Still none.
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| Always-log over hide-button | Diagnostics are cheap; one-line log per failure does not pollute. |
+| Ref-struct refusal is a name match | The DAP `Variable.type` is the cheapest signal we have; perfect detection requires reflection we cannot do. |
+| Centralized messages module | Lets PBI-005 integration tests assert wording without false positives from i18n. |
+
+## Acceptance criteria
+
+- View Logs button reveals a relevant entry for any failed invocation, even with `trace: false`.
+- Right-clicking a `Span<int>` produces "Cannot serialize ref-struct types"; no evaluate is issued.
+- Side-effect dialog has two distinct buttons; running with `noDebug: true` skips it entirely.
+- Menu uses `$(copy)`.
+- Existing tests updated to import message constants instead of hard-coded strings.
+
+## UAT checklist
+
+| # | Scenario | Expected result |
+|---|---|---|
+| 1 | Trigger any failure with `trace: false`, then click **View Logs** | Output channel contains a one-line entry naming the failure. |
+| 2 | Right-click a `Span<int>` local | Refusal toast; no clipboard write. |
+| 3 | First-use side-effect dialog | Two clearly distinct buttons; pressing **Don't show again** prevents re-display. |
+| 4 | Launch with `noDebug: true`, trigger Copy as JSON | No side-effect dialog. |
+| 5 | Inspect menu icon | `$(copy)`, not `$(clippy)`. |
+
+## Telemetry
+
+None.

--- a/docs/pbi-007-workflow-supply-chain-hardening.md
+++ b/docs/pbi-007-workflow-supply-chain-hardening.md
@@ -1,0 +1,48 @@
+# PBI-007: Workflow and supply-chain hardening
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (W1, W2, W4, R6).
+
+## Goal
+
+Reduce the blast radius of a compromised third-party action and prevent runtime dependencies from sneaking into the published `.vsix`.
+
+## Scope
+
+In:
+
+- **W1 / SHA-pin third-party actions.** Replace `softprops/action-gh-release@v3` (and any other non-GitHub-owned action we add later) with a 40-char commit SHA + version comment. `actions/checkout` and `actions/setup-node` are GitHub-owned and may stay on `vN`.
+- **W2 / Scoped permissions.** `release.yml`'s top-level `permissions: contents: write` is broad. Move the `write` to the `release` job only; default the rest of the workflow to `permissions: read-all` (or per-job `contents: read`).
+- **W4 / Dependabot for GitHub Actions.** Confirm the `github-actions` ecosystem is enabled in `dependabot.yml`. SHA pins make Dependabot more useful, not less.
+- **R6 / `--no-dependencies` enforcement.** Update the `vscode:prepublish` script (or add a thin wrapper in CI) so that any non-`devDependencies` entry in `package.json` causes the package step to fail loudly. The intent is "this extension has zero runtime deps" and the build should enforce it.
+- Document the policy in `docs/release.md` (new file): which actions are pinned, how to bump them, why we use `npm install --omit=optional` in CI.
+
+Out:
+
+- Provenance / SLSA attestations on the `.vsix`. Worth doing, but is its own PBI.
+- Sigstore signing of the `.vsix`. Same.
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| Pin only third-party actions | First-party actions are signed and rotated by GitHub itself; pinning them just creates upgrade churn. |
+| Per-job permissions | Smaller blast radius; matches GitHub's own recommendation. |
+| Build-time guard, not just convention | "Don't add runtime deps" is the kind of rule that decays without enforcement. |
+
+## Acceptance criteria
+
+- `softprops/action-gh-release` (and any future third-party action) is referenced by full SHA with `# vX.Y.Z` comment.
+- `release.yml` has no top-level `permissions: contents: write`. Only the publishing job has write scope.
+- A test commit that adds a runtime dep to `package.json` causes the package step to fail with a readable message.
+- Dependabot opens PRs for both `npm` and `github-actions` ecosystems.
+- `docs/release.md` exists and is linked from `README.md`.
+
+## UAT checklist
+
+Not user-facing; covered by green CI on a follow-up PR that intentionally adds a runtime dep (then reverts).
+
+## Telemetry
+
+None.

--- a/docs/pbi-008-type-checked-eslint.md
+++ b/docs/pbi-008-type-checked-eslint.md
@@ -1,0 +1,47 @@
+# PBI-008: Adopt type-checked ESLint preset
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (S2).
+
+## Goal
+
+Move from `tsPlugin.configs.recommended` to `tsPlugin.configs.recommendedTypeChecked` so that the linter catches the bugs we actually have - unhandled promises, unsafe `any`, redundant `await` - instead of stopping at syntax-level rules.
+
+## Scope
+
+In:
+
+- Update `eslint.config.mjs`:
+  - Add a `parserOptions.project` pointing at `tsconfig.json`.
+  - Spread `tsPlugin.configs.recommendedTypeChecked.rules` for `src/**/*.ts`.
+  - Re-tune the noisy rules (`no-misused-promises`, `no-floating-promises` stay on; `no-unsafe-*` start as `warn`).
+- Fix the resulting findings, in particular any floating promises around `customRequest` and the side-effect dialog.
+- Add a separate, lighter override block for tests (no `recommendedTypeChecked`, since Mocha's `suite/test` typings make it noisy).
+
+Out:
+
+- Migrating to `eslint-plugin-import` or `prettier`. Out of scope.
+- Replacing the test runner. Still TDD Mocha.
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| Type-checked preset for `src`, plain for tests | Tests are the noisiest area for the strict rules and the lowest-value place to enforce them. |
+| `no-unsafe-*` as `warn`, not `error` | Lets us land the upgrade without a giant cleanup PR; we can ratchet later. |
+
+## Acceptance criteria
+
+- `npm run lint` runs with `recommendedTypeChecked` and exits clean.
+- `no-floating-promises` and `no-misused-promises` are `error`.
+- The CI job that runs `lint` is unchanged (no special flags needed).
+- A deliberately introduced floating promise in `extension.ts` fails lint locally.
+
+## UAT checklist
+
+Not user-facing.
+
+## Telemetry
+
+None.

--- a/docs/pbi-009-marketplace-publish-prep.md
+++ b/docs/pbi-009-marketplace-publish-prep.md
@@ -1,0 +1,56 @@
+# PBI-009: Marketplace publish prep
+
+## Status
+
+Proposed. Derived from code review of `v0.0.1` (D1, D2, D3, D4, supply-chain note on `uuid`).
+
+## Goal
+
+Prepare a `0.1.0` build that can ship to the VS Code Marketplace without embarrassment: accurate README, proper marketplace metadata, an icon, and a clean dependency tree without forward-dated overrides.
+
+## Scope
+
+In:
+
+- **D1.** Correct the README section that implies the extension handles arbitrarily large objects. Document the per-attempt timeout and the truncation behavior PBI-002 will surface.
+- **D2.** Document the `csharpDebugCopyAsJson.allowedDebugTypes` setting and how it relates to the `when` clause on the menu (today the README implies the setting is the only gate).
+- **D3.** Move the `[Unreleased]` section of `CHANGELOG.md` into a `0.1.0` heading on release; restore an empty `[Unreleased]` skeleton.
+- **D4.** Add an icon (128x128 PNG, low-noise; placeholder in `media/icon.png`), a `categories` array (`Debuggers`, `Other`), `keywords` (`csharp`, `dotnet`, `debug`, `json`, `clipboard`), `repository`, `bugs`, `homepage` fields in `package.json`.
+- **`uuid` override.** Re-evaluate the `"uuid": "^14.0.0"` entry in `package.json` `overrides`. If the upstream `@vscode/vsce` 3.x has caught up by publish time, drop it. If it has not, document why we keep it.
+- Dry-run the publish via `vsce package --no-dependencies` and `vsce ls`, sanity-check the file list.
+- Bump version to `0.1.0` in `package.json` and tag accordingly (release flow already handled by existing workflow + PBI-007).
+
+Out:
+
+- Actually publishing to the Marketplace. That decision is the maintainer's, not this PBI's.
+- Localized README. Future work.
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| Ship as `0.1.0`, not `0.0.2` | Signals "first publish-quality build" without claiming `1.0`. |
+| Drop `uuid` override if possible | Pinning transitive deps is technical debt; only keep when justified. |
+| Single PNG icon, no SVG | Marketplace requires a PNG; SVG is rasterized anyway. |
+
+## Acceptance criteria
+
+- README sections on size limits, timeouts, and the `allowedDebugTypes` setting reflect the actual behavior.
+- `CHANGELOG.md` has a populated `0.1.0` section.
+- `package.json` includes `icon`, `categories`, `keywords`, `repository`, `bugs`, `homepage`.
+- `vsce package --no-dependencies` produces a `.vsix` whose file list contains no `src/`, no `samples/`, no `node_modules/` (extends the work in `.vscodeignore`).
+- The `overrides` block either no longer contains `uuid` or contains a comment explaining why.
+- A new `v0.1.0` tag triggers the release workflow and produces a `.vsix` attached to a GitHub Release. (Marketplace publish is a separate manual step.)
+
+## UAT checklist
+
+| # | Scenario | Expected result |
+|---|---|---|
+| 1 | Read the README end-to-end | No claims that contradict observed behavior in PBI-001 / PBI-002. |
+| 2 | Open the `.vsix` from the GitHub Release in `unzip -l` | No `src/`, `samples/`, or test files. |
+| 3 | Install the `.vsix` in a fresh VS Code profile | Icon appears in Extensions sidebar; categories filter finds it under **Debuggers**. |
+| 4 | `npm audit --omit=dev` | Zero vulnerabilities. |
+
+## Telemetry
+
+None.


### PR DESCRIPTION
## Summary

Captures the eight follow-up workstreams identified by the post-`v0.0.1` code review as their own PBI files under `docs/`, plus an index in `docs/README.md`.

| PBI | Title | Closes review item(s) |
|---|---|---|
| 002 | Validate evaluate result before clipboard write | C1, R1, R5 |
| 003 | Stable detection of `supportsClipboardContext` | C3 |
| 004 | Re-validate stack frame after the side-effect warning | C2 |
| 005 | `@vscode/test-electron` activation/integration harness | T1 |
| 006 | UX polish and edge-case messaging | R2, R3, R4, S1 |
| 007 | Workflow and supply-chain hardening | W1, W2, W4, R6 |
| 008 | Adopt type-checked ESLint preset | S2 |
| 009 | Marketplace publish prep (`0.1.0`) | D1-D4, drops `uuid` override |

Each PBI follows the existing `pbi-001` template (Status / Goal / Scope (in/out) / Architectural decisions / Acceptance criteria / UAT / Telemetry).

Suggested execution order is documented in `docs/README.md`:

1. **PBI-005** first - the harness gives the criticals testable AC.
2. **PBI-002 / 003 / 004** in parallel - the three independent criticals.
3. **PBI-007 / 008** in parallel - infra, no user-visible risk.
4. **PBI-006** - UX polish, batches with whichever critical lands last.
5. **PBI-009** - last; gates `v0.1.0`.

## Test plan

- [ ] Skim each PBI doc in the PR diff for accuracy and tone.
- [ ] Confirm the dependency call-outs in `docs/README.md` match how you actually want to sequence the work.
- [ ] Decide whether PBI-006 should stay as a bundle or split into one PBI per review item.
- [ ] Decide whether PBI-009 should keep the `0.1.0` version bump or be softened to "publish-prep without bump".