### PR TITLE
test(PBI-005): @vscode/test-electron harness with activation smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Keep this in sync with DEFAULT_VSCODE_VERSION in
+  # src/test/integration/runIntegration.ts. The cache key below depends on it,
+  # so bumping this value will invalidate the cache on the next run.
+  VSCODE_TEST_VERSION: 1.89.0
+
 jobs:
   build:
     name: Lint, compile, test, package
@@ -27,14 +33,20 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund --omit=optional
 
+      - name: Cache VS Code test binary
+        uses: actions/cache@v4
+        with:
+          path: .vscode-test
+          key: vscode-test-${{ runner.os }}-${{ env.VSCODE_TEST_VERSION }}
+
       - name: Lint
         run: npm run lint
 
       - name: Compile
         run: npm run compile
 
-      - name: Unit tests
-        run: npm test
+      - name: Tests (unit + integration, headless)
+        run: xvfb-run -a npm test
 
       - name: Package VSIX
         run: npx --yes @vscode/vsce package --no-dependencies --out vscode-csharp-copy-as-json.vsix

--- a/docs/pbi-005-activation-integration-tests.md
+++ b/docs/pbi-005-activation-integration-tests.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Proposed. Derived from code review of `v0.0.1` (test-coverage gap T1, prerequisite for PBI-002/003/004 acceptance tests).
+**In progress.** Phase 1 (harness + activation smoke) is delivered by branch `feature/pbi-005-test-electron-harness`. Phase 2 items below are deferred and will be picked up alongside the PBIs that consume them.
+
+| Phase | Items | Status |
+|---|---|---|
+| 1 (harness) | `@vscode/test-electron` runner, Mocha glob, activation smoke, CI wiring | This PR |
+| 2 (utility coverage) | `withTimeout` and `looksLikeError` tests | Deferred; lands with **PBI-002** |
+| 2 (fake DAP) | In-process fake adapter exercising success and all-contexts-failed paths | Deferred; lands with **PBI-002** / **PBI-003** since each needs a different fake |
+
+Rationale: the harness has its own plumbing risk (test-electron download pinning, headless `xvfb` on Linux, Electron version drift). Landing it on its own keeps any harness-level CI failure attributable instead of blamed on test logic. The fake-DAP work splits naturally with the PBIs that consume it - PBI-002's tests need truncation injection, PBI-003's tests need a tracker that omits `supportsClipboardContext`. Purpose-built fakes beat speculative generalization.
 
 ## Goal
 
@@ -34,6 +42,9 @@ Out:
 | `@vscode/test-electron`, not `@vscode/test-cli` | The extension targets the legacy `--ui tdd` Mocha runner (carried from PBI-001). Switching test runners is out of scope. |
 | In-process fake adapter | A real `coreclr` launch would balloon CI time and leak platform-specific issues into the test signal. |
 | Only Linux electron in CI | Cheapest signal; the extension is JS, not native. |
+| Pin the test-host VS Code to the `engines.vscode` floor (currently `1.89.0`) | If the floor passes, the minimum-supported promise is honored. Override via `VSCODE_TEST_VERSION` env var for ad-hoc runs against `stable` / `insiders`. The pin paid for itself on day one: it caught `glob@11`/`lru-cache@11` calling `node:diagnostics_channel.tracingChannel` (a Node 19+ API) inside VS Code 1.89's Electron 28 / Node 18 host, before that dep ever shipped. |
+| Cache `.vscode-test/` keyed by the pinned version | Avoids re-downloading ~120 MB of VS Code on every CI run; cache key invalidates automatically when the pin is bumped. |
+| No external `glob` dep in the test runner | A 6-line `fs.readdirSync` walker discovers `*.test.js` and avoids the `glob -> path-scurry -> lru-cache@11` chain that requires Node 19+. We control the test layout, so a globbing library is overkill. |
 
 ## Acceptance criteria
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "@vscode/debugprotocol": "^1.66.0",
+        "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.9.1",
         "eslint": "^10.2.1",
         "mocha": "^11.7.5",
@@ -1062,6 +1063,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@vscode/vsce": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
@@ -1599,6 +1617,35 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1694,6 +1741,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2572,6 +2626,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2879,6 +2946,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2907,8 +2981,7 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -2986,6 +3059,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3044,6 +3130,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3183,6 +3276,52 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -3251,6 +3390,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/linkify-it": {
@@ -3465,6 +3614,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -3885,6 +4047,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -3920,6 +4098,111 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -3973,6 +4256,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
       "version": "8.3.0",
@@ -4201,6 +4491,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4407,6 +4704,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -4537,6 +4851,13 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4765,6 +5086,19 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -5302,8 +5636,7 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,10 @@
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
     "lint": "eslint \"src/**/*.ts\"",
-    "test": "npm run compile && mocha --ui tdd \"out/test/**/*.test.js\"",
+    "pretest": "npm run compile",
+    "test:unit": "mocha --ui tdd \"out/test/*.test.js\"",
+    "test:integration": "node out/test/integration/runIntegration.js",
+    "test": "npm run test:unit && npm run test:integration",
     "package": "vsce package --no-dependencies"
   },
   "devDependencies": {
@@ -103,6 +106,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "@vscode/debugprotocol": "^1.66.0",
+    "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.9.1",
     "eslint": "^10.2.1",
     "mocha": "^11.7.5",

--- a/src/test/integration/activation.test.ts
+++ b/src/test/integration/activation.test.ts
@@ -1,0 +1,39 @@
+import * as assert from "node:assert/strict";
+import * as vscode from "vscode";
+
+const EXTENSION_ID = "JadeEye21.vscode-csharp-copy-as-json";
+const COMMAND_ID = "csharpDebugCopyAsJson.copyAsJson";
+
+suite("activation smoke", () => {
+  test("extension is present and activates", async function () {
+    this.timeout(30_000);
+
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(
+      ext,
+      `extension '${EXTENSION_ID}' is not installed in the test host`,
+    );
+
+    await ext.activate();
+    assert.equal(ext.isActive, true, "extension did not activate cleanly");
+  });
+
+  test("copyAsJson command is registered", async function () {
+    this.timeout(30_000);
+
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(ext, `extension '${EXTENSION_ID}' missing`);
+    if (!ext.isActive) {
+      await ext.activate();
+    }
+
+    const commands = await vscode.commands.getCommands(true);
+    const ours = commands.filter((c) =>
+      c.startsWith("csharpDebugCopyAsJson."),
+    );
+    assert.ok(
+      ours.includes(COMMAND_ID),
+      `expected '${COMMAND_ID}' to be registered; saw [${ours.join(", ") || "none"}]`,
+    );
+  });
+});

--- a/src/test/integration/index.ts
+++ b/src/test/integration/index.ts
@@ -1,0 +1,54 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import Mocha from "mocha";
+
+// Discover *.test.js files under out/test/integration/, recursing one level
+// in case future tests are grouped into subfolders. We deliberately avoid the
+// `glob` package: its transitive lru-cache@11 calls Node 19+ APIs
+// (`diagnostics_channel.tracingChannel`) which crash inside the Electron
+// renderer of older VS Code versions we still support (engines.vscode floor
+// is 1.89, which bundles Node 18).
+function findTestFiles(root: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && entry.name.endsWith(".test.js")) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+export async function run(): Promise<void> {
+  const mocha = new Mocha({
+    ui: "tdd",
+    color: true,
+    // Activation can take a while on a cold test-electron download.
+    timeout: 60_000,
+  });
+
+  const testsRoot = path.resolve(__dirname);
+  for (const file of findTestFiles(testsRoot)) {
+    mocha.addFile(file);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      mocha.run((failures) => {
+        if (failures > 0) {
+          reject(new Error(`${failures} integration test(s) failed.`));
+        } else {
+          resolve();
+        }
+      });
+    } catch (err) {
+      reject(err as Error);
+    }
+  });
+}

--- a/src/test/integration/runIntegration.ts
+++ b/src/test/integration/runIntegration.ts
@@ -1,0 +1,30 @@
+import * as path from "node:path";
+import { runTests } from "@vscode/test-electron";
+
+// Pin to our engines.vscode floor so a passing CI run proves the
+// minimum-supported promise still holds. Override with VSCODE_TEST_VERSION
+// (e.g. "stable" or "insiders") for ad-hoc runs against newer builds.
+const DEFAULT_VSCODE_VERSION = "1.89.0";
+
+async function main(): Promise<void> {
+  try {
+    // Workspace root — two levels up from out/test/integration/.
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../..");
+    // Mocha runner module that adds and runs the *.test.js files.
+    const extensionTestsPath = path.resolve(__dirname, "./index");
+
+    await runTests({
+      version: process.env.VSCODE_TEST_VERSION ?? DEFAULT_VSCODE_VERSION,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      // Disable other installed extensions so the host is deterministic and
+      // a stray third-party extension cannot break activation.
+      launchArgs: ["--disable-extensions"],
+    });
+  } catch (err) {
+    console.error("Failed to run integration tests:", err);
+    process.exit(1);
+  }
+}
+
+void main();


### PR DESCRIPTION
Closes phase 1 of [PBI-005](../blob/main/docs/pbi-005-activation-integration-tests.md). Phase 2 (withTimeout / looksLikeError unit coverage and a fake DAP) is deferred to the PBIs that consume those fakes (PBI-002, PBI-003).

## Summary

- Adds an `@vscode/test-electron` harness under `src/test/integration/`.
- Activation smoke test: extension loads in a real VS Code, command \`csharpDebugCopyAsJson.copyAsJson\` is registered.
- `npm test` now runs unit + integration end-to-end. CI uses \`xvfb-run -a\` for a headless display.

## Risk mitigations baked in

- **Pinned the test-host VS Code to \`engines.vscode\` floor (\`1.89.0\`).** A green run proves our minimum-supported promise. Override with the \`VSCODE_TEST_VERSION\` env var to test against \`stable\` or \`insiders\` ad-hoc.
- **Cached \`.vscode-test/\` in CI**, keyed by the pinned version, so the ~120 MB VS Code download is not paid on every run.
- **Dropped the \`glob\` dep in the test runner.** \`glob@11\`'s transitive \`lru-cache@11\` calls \`node:diagnostics_channel.tracingChannel\` (Node 19+), which crashes inside VS Code 1.89's Electron 28 / Node 18 host. \`fs.readdirSync\` is enough for the test layout we control.

## What this enables

PBI-002 / PBI-003 / PBI-004 can now express acceptance criteria as automated tests instead of manual UAT only.

## Test plan

- [x] \`npm test\` green locally (20 unit + 2 integration), against pinned VS Code 1.89.0.
- [x] \`.vscode-test/\` reused on second run (no re-download).
- [ ] CI green on the PR. The first CI run downloads VS Code 1.89.0 (~30-60 s); subsequent runs use the \`actions/cache\` entry.

Made with [Cursor](https://cursor.com)