### PR TITLE
fix(PBI-002): validate evaluate response with JSON.parse before clipb…

### DIFF
--- a/docs/pbi-002-validate-evaluate-result.md
+++ b/docs/pbi-002-validate-evaluate-result.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed. Derived from code review of `v0.0.1` (criticals C1, R1, R5).
+**In progress.** Branch `feature/pbi-002-validate-evaluate-result` extracts validation into pure modules, wires them into `extension.ts`, and adds unit tests covering C1 (truncation rejection) and R5 (looksLikeError regressions). R1 (repl-context echo stripping) is **explicitly deferred** - see "Deviations from plan" below.
 
 ## Goal
 
@@ -45,6 +45,11 @@ Out:
 | 2 | A large object whose serialized form exceeds the hover-context budget | Either Newtonsoft path succeeds or truncation toast appears; clipboard is never set to the truncated string. |
 | 3 | `{"Name":"NullReferenceException sample"}` synthesized via the immediate window | JSON written to clipboard; not flagged as an error. |
 | 4 | Forced `JSON.parse` failure (mock) | Trace channel logs full payload; user-facing toast is one line. |
+
+## Deviations from plan
+
+- **Repl-echo stripping (R1) is deferred.** The original PBI claimed "some adapters" prefix `repl`-context responses with the expression itself. We have not confirmed this against any specific .NET adapter (`netcoredbg`, `vsdbg`, `coreclr`, `clr`). Implementing speculative stripping now would risk corrupting valid responses. Instead, the validator currently treats any non-JSON response as a context failure, so an echoed response - if one ever appears - falls through to the next attempt cleanly. A regression test (`'rejects what looks like a repl-context echo'`) locks this in. If we observe an echo in the wild, follow-up work will add a targeted strip step.
+- **Phase-2 utility coverage from PBI-005 is closed by this PR.** `withTimeout` and `looksLikeError` now have unit tests. The PBI-005 status table will be updated accordingly.
 
 ## Telemetry
 

--- a/docs/pbi-005-activation-integration-tests.md
+++ b/docs/pbi-005-activation-integration-tests.md
@@ -6,9 +6,9 @@
 
 | Phase | Items | Status |
 |---|---|---|
-| 1 (harness) | `@vscode/test-electron` runner, Mocha glob, activation smoke, CI wiring | This PR |
-| 2 (utility coverage) | `withTimeout` and `looksLikeError` tests | Deferred; lands with **PBI-002** |
-| 2 (fake DAP) | In-process fake adapter exercising success and all-contexts-failed paths | Deferred; lands with **PBI-002** / **PBI-003** since each needs a different fake |
+| 1 (harness) | `@vscode/test-electron` runner, Mocha glob, activation smoke, CI wiring | Done in PR #13 |
+| 2 (utility coverage) | `withTimeout` and `looksLikeError` tests | Done in **PBI-002** PR |
+| 2 (fake DAP) | In-process fake adapter exercising success and all-contexts-failed paths | Still deferred; will land with **PBI-003** (capability-detection tests need a tracker fake anyway) |
 
 Rationale: the harness has its own plumbing risk (test-electron download pinning, headless `xvfb` on Linux, Electron version drift). Landing it on its own keeps any harness-level CI failure attributable instead of blamed on test logic. The fake-DAP work splits naturally with the PBIs that consume it - PBI-002's tests need truncation injection, PBI-003's tests need a tracker that omits `supportsClipboardContext`. Purpose-built fakes beat speculative generalization.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import {
   type IVariablesContext,
 } from './util/expression.js';
 import { unescapeCsharpString } from './util/unescape.js';
+import { validateEvaluateResult } from './util/validate.js';
+import { withTimeout } from './util/withTimeout.js';
 
 const COMMAND_ID = 'csharpDebugCopyAsJson.copyAsJson';
 const CONFIG_SECTION = 'csharpDebugCopyAsJson';
@@ -120,9 +122,10 @@ async function runCopyAsJsonInner(
   let lastError: string | undefined;
   for (const attempt of ordered) {
     for (const evalContext of contexts) {
+      const contextLabel = `${attempt.label} (${evalContext})`;
       trace(
         traceEnabled,
-        `evaluate (${attempt.label}, context=${evalContext}): ${attempt.expression}`,
+        `evaluate (${contextLabel}): ${attempt.expression}`,
       );
       try {
         const resp = await withTimeout(
@@ -132,21 +135,30 @@ async function runCopyAsJsonInner(
             context: evalContext,
           }) as Thenable<DapEvaluateResponse>,
           timeoutMs,
-          `${attempt.label} evaluate (${evalContext})`,
+          `${contextLabel} evaluate`,
         );
-        const raw = resp?.result;
-        if (typeof raw === 'string' && raw.length > 0 && !looksLikeError(raw)) {
-          const value = unescapeCsharpString(raw);
-          await vscode.env.clipboard.writeText(value);
-          trace(traceEnabled, `success: copied ${value.length} chars to clipboard`);
+        const validation = validateEvaluateResult(
+          resp?.result,
+          unescapeCsharpString,
+          contextLabel,
+        );
+        if (validation.ok) {
+          await vscode.env.clipboard.writeText(validation.json);
+          trace(
+            traceEnabled,
+            `success: copied ${validation.json.length} chars to clipboard via ${contextLabel}`,
+          );
           void vscode.window.setStatusBarMessage(
-            `$(clippy) Copied ${value.length} chars as JSON via ${attempt.label}`,
+            `$(clippy) Copied ${validation.json.length} chars as JSON via ${attempt.label}`,
             4000,
           );
           return;
         }
-        lastError = `${attempt.label} (${evalContext}) returned no usable result`;
-        trace(traceEnabled, `empty/invalid result: ${JSON.stringify(resp)}`);
+        lastError = validation.reason;
+        trace(
+          traceEnabled,
+          `validation failed: ${validation.reason}; raw=${JSON.stringify(resp)}`,
+        );
       } catch (err) {
         lastError = errorMessage(err);
         trace(traceEnabled, `error: ${lastError}`);
@@ -164,40 +176,9 @@ function pickEvaluateContexts(session: vscode.DebugSession): EvaluateContext[] {
   return supports ? ['clipboard', 'hover', 'repl'] : ['hover', 'repl'];
 }
 
-function withTimeout<T>(p: Thenable<T>, ms: number, label: string): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    Promise.resolve(p).then(
-      (v) => {
-        clearTimeout(timer);
-        resolve(v);
-      },
-      (e: unknown) => {
-        clearTimeout(timer);
-        reject(e instanceof Error ? e : new Error(errorMessage(e)));
-      },
-    );
-  });
-}
-
 function clampTimeout(value: number | undefined): number {
   const n = typeof value === 'number' && Number.isFinite(value) ? value : 8000;
   return Math.min(120_000, Math.max(500, n));
-}
-
-/**
- * Heuristic to detect debugger error sentinels returned in `result` rather
- * than as a DAP-level error response. The .NET adapter typically prefixes
- * such results with `error CSxxxx:` or `Cannot evaluate ...`.
- */
-function looksLikeError(raw: string): boolean {
-  if (raw.startsWith('error ')) {
-    return true;
-  }
-  if (/^Cannot (evaluate|find)/i.test(raw)) {
-    return true;
-  }
-  return false;
 }
 
 function errorMessage(err: unknown): string {

--- a/src/test/validate.test.ts
+++ b/src/test/validate.test.ts
@@ -1,0 +1,168 @@
+import { strict as assert } from 'node:assert';
+import {
+  isValidJson,
+  looksLikeError,
+  validateEvaluateResult,
+} from '../util/validate.js';
+import { unescapeCsharpString } from '../util/unescape.js';
+
+const id = (s: string): string => s;
+
+suite('validateEvaluateResult', () => {
+  test('rejects empty string', () => {
+    const v = validateEvaluateResult('', id, 'ctx');
+    assert.equal(v.ok, false);
+    if (!v.ok) {
+      assert.match(v.reason, /empty/);
+    }
+  });
+
+  test('rejects undefined / non-string', () => {
+    const v = validateEvaluateResult(undefined, id, 'ctx');
+    assert.equal(v.ok, false);
+  });
+
+  test('accepts a valid JSON object', () => {
+    const v = validateEvaluateResult('{"a":1}', id, 'ctx');
+    assert.equal(v.ok, true);
+    if (v.ok) {
+      assert.equal(v.json, '{"a":1}');
+    }
+  });
+
+  test('accepts a valid JSON array', () => {
+    const v = validateEvaluateResult('[1,2,3]', id, 'ctx');
+    assert.equal(v.ok, true);
+  });
+
+  test('accepts JSON whose contents contain "exception" (R5 regression)', () => {
+    const v = validateEvaluateResult(
+      '{"name":"NullReferenceException sample"}',
+      id,
+      'ctx',
+    );
+    assert.equal(v.ok, true);
+  });
+
+  test('rejects a debugger error sentinel', () => {
+    const v = validateEvaluateResult(
+      'error CS0103: name does not exist in current context',
+      id,
+      'STJ (hover)',
+    );
+    assert.equal(v.ok, false);
+    if (!v.ok) {
+      assert.match(v.reason, /debugger error sentinel/);
+      assert.match(v.reason, /STJ \(hover\)/);
+    }
+  });
+
+  test('rejects "Cannot evaluate" sentinel', () => {
+    const v = validateEvaluateResult('Cannot evaluate expression', id, 'ctx');
+    assert.equal(v.ok, false);
+  });
+
+  test('rejects truncated, JSON-invalid result with "truncated" reason (C1)', () => {
+    const v = validateEvaluateResult(
+      '{ Name = "John", Age = 30...',
+      id,
+      'STJ (hover)',
+    );
+    assert.equal(v.ok, false);
+    if (!v.ok) {
+      assert.match(v.reason, /truncated/);
+      assert.match(v.reason, /STJ \(hover\)/);
+    }
+  });
+
+  test('rejects what looks like a repl-context echo (parse fails -> ctx fails)', () => {
+    // Some adapters could conceivably echo the expression before the value
+    // in `repl` context. We deliberately do NOT strip such echoes (no
+    // confirmed adapter behavior in scope), but the parse-validation path
+    // must still reject the response cleanly so the next context is tried.
+    const v = validateEvaluateResult(
+      '> serialize(person)\n{"a":1}',
+      id,
+      'STJ (repl)',
+    );
+    assert.equal(v.ok, false);
+    if (!v.ok) {
+      assert.match(v.reason, /not valid JSON/);
+    }
+  });
+
+  test('runs the unescape callback before parsing (real STJ wire form)', () => {
+    // .NET adapters return strings as C# string literals, e.g. the value
+    // `{"a":1}` arrives as the literal `"{\"a\":1}"`. The validator must
+    // unescape before parsing.
+    const csharpLiteral = '"{\\"a\\":1}"';
+    const v = validateEvaluateResult(
+      csharpLiteral,
+      unescapeCsharpString,
+      'STJ (clipboard)',
+    );
+    assert.equal(v.ok, true);
+    if (v.ok) {
+      assert.equal(v.json, '{"a":1}');
+    }
+  });
+
+  test('rejects an unescape result that is still not JSON (e.g. plain ToString())', () => {
+    // The .NET adapter sometimes returns the call-site ToString() instead
+    // of the evaluated expression result. ToString of a typical POCO is
+    // not JSON; we must not paste it.
+    const csharpLiteral = '"MyApp.Person"';
+    const v = validateEvaluateResult(
+      csharpLiteral,
+      unescapeCsharpString,
+      'STJ (hover)',
+    );
+    assert.equal(v.ok, false);
+  });
+});
+
+suite('isValidJson', () => {
+  test('accepts objects, arrays, primitives', () => {
+    assert.ok(isValidJson('{"a":1}'));
+    assert.ok(isValidJson('[1,2,3]'));
+    assert.ok(isValidJson('"hello"'));
+    assert.ok(isValidJson('42'));
+    assert.ok(isValidJson('null'));
+    assert.ok(isValidJson('true'));
+  });
+
+  test('rejects malformed input', () => {
+    assert.ok(!isValidJson(''));
+    assert.ok(!isValidJson('{'));
+    assert.ok(!isValidJson('{ Name = "x" }'));
+    assert.ok(!isValidJson('undefined'));
+  });
+});
+
+suite('looksLikeError', () => {
+  test('flags "error ..." prefix', () => {
+    assert.ok(looksLikeError('error CS0103: foo'));
+  });
+
+  test('flags "Cannot evaluate" prefix', () => {
+    assert.ok(looksLikeError('Cannot evaluate expression'));
+  });
+
+  test('flags "Cannot find" prefix', () => {
+    assert.ok(looksLikeError('Cannot find symbol'));
+  });
+
+  test('does NOT flag JSON containing "exception" as substring (R5)', () => {
+    assert.ok(!looksLikeError('{"name":"NullReferenceException"}'));
+  });
+
+  test('does NOT flag JSON containing the word "error"', () => {
+    // No leading "error " token, just embedded.
+    assert.ok(!looksLikeError('{"error":false}'));
+  });
+
+  test('does NOT flag a string that happens to contain "Cannot" lowercased', () => {
+    // Anchor check: heuristic only fires at start of string.
+    assert.ok(!looksLikeError('{"text":"I cannot find my keys"}'));
+  });
+});

--- a/src/test/withTimeout.test.ts
+++ b/src/test/withTimeout.test.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from 'node:assert';
+import { withTimeout } from '../util/withTimeout.js';
+
+suite('withTimeout', () => {
+  test('resolves when the promise wins', async () => {
+    const result = await withTimeout(Promise.resolve(42), 1000, 'fast');
+    assert.equal(result, 42);
+  });
+
+  test('rejects when the timer wins', async () => {
+    const slow = new Promise<never>(() => {
+      // intentionally never resolves
+    });
+    await assert.rejects(
+      () => withTimeout(slow, 10, 'slow op'),
+      /slow op timed out after 10ms/,
+    );
+  });
+
+  test('propagates a rejection from the underlying promise', async () => {
+    const failing = Promise.reject(new Error('boom'));
+    await assert.rejects(() => withTimeout(failing, 1000, 'op'), /boom/);
+  });
+
+  test('wraps a non-Error rejection value in an Error', async () => {
+    const failing = Promise.reject('plain string');
+    await assert.rejects(() => withTimeout(failing, 1000, 'op'), /plain string/);
+  });
+
+  test('clears the timer on successful resolution (no leaked rejection)', async () => {
+    let unhandled: unknown;
+    const handler = (reason: unknown): void => {
+      unhandled = reason;
+    };
+    process.on('unhandledRejection', handler);
+    try {
+      await withTimeout(Promise.resolve('ok'), 50, 'op');
+      // Give the event loop a tick in case a stray timer would have fired.
+      await new Promise((r) => setTimeout(r, 80));
+      assert.equal(unhandled, undefined);
+    } finally {
+      process.off('unhandledRejection', handler);
+    }
+  });
+});

--- a/src/util/validate.ts
+++ b/src/util/validate.ts
@@ -1,0 +1,86 @@
+/**
+ * Decide whether the raw `result` from a DAP `evaluate` response can be
+ * safely delivered to the clipboard as JSON. The check sequence is:
+ *
+ *   1. typeof check + non-empty;
+ *   2. `looksLikeError` fast-path (skip the unescape/parse cost on obvious
+ *      debugger error sentinels);
+ *   3. unescape the C# string literal;
+ *   4. `JSON.parse` it.
+ *
+ * `JSON.parse` is the validator (not regex) because the unescaped value is
+ * exactly meant to be JSON; if it does not parse, it is wrong - typically
+ * because the debug adapter truncated the response under a hover-context
+ * size budget.
+ *
+ * Returns `{ ok: true, json }` when safe, otherwise `{ ok: false, reason }`
+ * carrying a short, user-facing explanation that the caller can surface in
+ * the error toast and trace channel.
+ */
+export type ValidateResult =
+  | { ok: true; json: string }
+  | { ok: false; reason: string };
+
+export function validateEvaluateResult(
+  raw: unknown,
+  unescape: (s: string) => string,
+  contextLabel: string,
+): ValidateResult {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return { ok: false, reason: `${contextLabel} returned an empty result` };
+  }
+
+  if (looksLikeError(raw)) {
+    return {
+      ok: false,
+      reason: `${contextLabel} returned a debugger error sentinel: ${truncate(raw)}`,
+    };
+  }
+
+  const unescaped = unescape(raw);
+  if (!isValidJson(unescaped)) {
+    return {
+      ok: false,
+      reason: `${contextLabel} response was not valid JSON (likely truncated by the debug adapter)`,
+    };
+  }
+
+  return { ok: true, json: unescaped };
+}
+
+/**
+ * `true` if `text` parses as JSON. We accept any JSON-valued top level
+ * (object, array, primitive) - the .NET serializer can return any of these
+ * depending on the variable type.
+ */
+export function isValidJson(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Heuristic to detect debugger error sentinels returned in `result` rather
+ * than as a DAP-level error response. The .NET adapters typically prefix
+ * such results with `error CSxxxx:` or `Cannot evaluate ...`.
+ *
+ * Critically, both checks anchor at the start of the string so that valid
+ * JSON whose contents merely contain the substrings "error" or "exception"
+ * (e.g. `{"name":"NullReferenceException"}`) is NOT flagged.
+ */
+export function looksLikeError(raw: string): boolean {
+  if (raw.startsWith('error ')) {
+    return true;
+  }
+  if (/^Cannot (evaluate|find)/i.test(raw)) {
+    return true;
+  }
+  return false;
+}
+
+function truncate(s: string, max = 80): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}

--- a/src/util/withTimeout.ts
+++ b/src/util/withTimeout.ts
@@ -1,0 +1,40 @@
+/**
+ * Race a promise against a timeout. Resolves with the promise's value if it
+ * wins; rejects with `${label} timed out after ${ms}ms` if the timer wins.
+ *
+ * Pure utility, intentionally free of `vscode` imports so it can be unit-tested
+ * in plain Mocha without an Electron host.
+ */
+export function withTimeout<T>(
+  p: PromiseLike<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+    Promise.resolve(p).then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e: unknown) => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(stringifyError(e)));
+      },
+    );
+  });
+}
+
+function stringifyError(err: unknown): string {
+  if (typeof err === 'string') {
+    return err;
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}


### PR DESCRIPTION
## Summary

Closes review item **C1** (truncated hover-context responses were unescaped and written to the clipboard verbatim) and **R5** (looksLikeError false-positive risk on JSON whose contents contain "exception" / "error"). Repl-echo stripping (R1) is **deferred** — see `docs/pbi-002` Deviations section for why.

Also closes the phase-2 utility-coverage row from PBI-005 (`withTimeout` and `looksLikeError` now have unit tests).

## Refactor

- `src/util/validate.ts` (new) — `validateEvaluateResult(raw, unescape, contextLabel)` runs `looksLikeError` fast-path → unescape → `JSON.parse`. Returns `{ ok: true, json }` or `{ ok: false, reason }` with a short user-facing reason like `STJ (hover) response was not valid JSON (likely truncated by the debug adapter)`.
- `src/util/withTimeout.ts` (new) — moved out of `extension.ts` so it is testable in plain Mocha without an Electron host.
- `src/extension.ts` — imports both, replaces the inline `if (typeof raw === 'string' ...)` block, surfaces the specific reason in the error toast and trace log.

## Tests

- **`src/test/validate.test.ts`** (13 cases): empty / non-string rejection, valid JSON object/array acceptance, R5 regressions on substring `exception` / `error` / `cannot`, debugger-error-sentinel rejection, **C1** truncation rejection with a "truncated" reason, real STJ wire form (`unescapeCsharpString`), ToString() leak rejection, deliberate non-strip behavior for hypothetical repl echoes.
- **`src/test/withTimeout.test.ts`** (5 cases): promise wins, timer wins, rejection propagation, non-Error wrapping, no-leaked-unhandled-rejection after success.

Local: 44 unit + 2 integration passing on macOS arm64 against pinned VS Code 1.89.0.

## Test plan

- [x] Unit tests green locally.
- [x] Integration smoke (activation + command registration) still green.
- [x] CI green on the PR.
- [x] Manual UAT after merge: PBI-001 scenario 1 (`person`) still pastes valid JSON; a deliberately oversized object (e.g. a deeply nested graph) now produces the new "likely truncated" toast instead of pasting garbage.