### PR TITLE
fix(PBI-003): replace duck-typed capability cast with DebugAdapterTracker

### DIFF
--- a/docs/pbi-003-stable-capability-detection.md
+++ b/docs/pbi-003-stable-capability-detection.md
@@ -2,7 +2,13 @@
 
 ## Status
 
-Proposed. Derived from code review of `v0.0.1` (critical C3).
+**In progress.** Production code and unit tests delivered on `feature/pbi-003-stable-capability-detection`.
+
+| Phase | Items | Status |
+|---|---|---|
+| 1 (replace cast) | `clipboardCapability` cache, `DebugAdapterTracker` registration, `onDidTerminateDebugSession` eviction, `onDebug` activation event, removal of the `as unknown as` cast | Done in this PR |
+| 1 (unit coverage) | 16 tests over the cache + tracker message-extraction logic | Done in this PR |
+| 2 (fake-DAP integration test) | Drive a fake `DebugAdapterInlineImplementation` end-to-end and assert the tracker→cache wiring | **Deferred again.** See "Deviations" below. |
 
 ## Goal
 
@@ -30,13 +36,21 @@ Out:
 | Prefer the tracker over probe-and-fallback | One round trip cheaper, and the answer is authoritative. |
 | Per-session cache, not per-extension | The user can have multiple debug sessions with different adapters; a global cache would be wrong. |
 | Keep `clipboard` as the first preference when supported | Mirrors VS Code's built-in "Copy Value" behavior (decision carried over from PBI-001). |
+| Register the tracker for `'*'`, not for `coreclr`/`clr` | The user can override `csharpDebugCopyAsJson.allowedDebugTypes` to add e.g. `mono` or `unity`. A no-op tracker on unrelated sessions costs one closure per session; that's cheaper than silently losing the capability when a non-default debug type is added. |
+| Add `activationEvents: ["onDebug"]` | Without it, the extension activates lazily on first command invocation - which happens *after* the user right-clicks a variable, well after `InitializeResponse`. The tracker would never see the response, the cache would always be empty, and `pickEvaluateContexts` would always return `['hover','repl']`, regressing PBI-001's clipboard-context support. |
+| Cache miss is treated as `false` (not `true`) | If the tracker missed for any reason, falling through to `hover` is correct on every adapter. Defaulting to `true` would attempt `clipboard` on adapters that reject it and surface a noisy error. |
+| Extracted the tracker logic into `createCapabilityTracker(sessionId)` | The message-extraction logic is the only thing worth testing; isolating it as a pure function lets the unit suite exercise every shape (success, failure, missing field, wrong command, event, junk) without needing an Electron host or fake adapter. |
+
+## Deviations from original plan
+
+- **Fake-DAP integration test deferred.** Driving a real `vscode.debug.startDebugging` call against a `DebugAdapterInlineImplementation` requires either contributing a `debuggers` entry in `package.json` (which would pollute the published Marketplace package with a "csharp-copy-test" debug type) or shipping a `DebugConfigurationProvider` shim with similar concerns. The cost - measured in package surface, not test code - is high relative to what it adds beyond the already-comprehensive unit coverage of `createCapabilityTracker`. The remaining untested surface is two lines of glue (`vscode.debug.registerDebugAdapterTrackerFactory` + `onDidTerminateDebugSession`), which is covered by manual UAT instead. If future PBIs (especially PBI-004's frame-stability work) need a fake adapter for their own reasons, we'll bundle a test-only `package.json` `debuggers` contribution then and retroactively add the integration assertion here.
 
 ## Acceptance criteria
 
-- No `as any` casts on `vscode.DebugSession` anywhere in `extension.ts`.
-- Manual run on VS Code 1.89, current stable, and current insiders: clipboard context is chosen exactly when the adapter advertises it.
-- Killing the extension's tracker (or running against an adapter that never sends `supportsClipboardContext`) results in `hover -> repl` being attempted, not a crash.
-- Unit / integration test asserts that a session whose tracker received `supportsClipboardContext: false` does not attempt a `clipboard` evaluate.
+- ✅ No `as any` / `as unknown as` casts on `vscode.DebugSession` anywhere in `extension.ts`.
+- 🔲 Manual run on VS Code 1.89, current stable, and current insiders: clipboard context is chosen exactly when the adapter advertises it. *(Manual UAT, owner: PR author.)*
+- ✅ Adapter that never sends `supportsClipboardContext` results in `hover -> repl` being attempted, not a crash. *(Covered by the unit test "caches false when InitializeResponse omits supportsClipboardContext" combined with the cache-miss=false rule in `pickEvaluateContexts`.)*
+- ⚠️ Test asserts that a session whose tracker received `supportsClipboardContext: false` does not attempt a `clipboard` evaluate. *(Asserted at the cache-API level: the tracker writes `false`, and `pickEvaluateContexts` reads from the cache and excludes `'clipboard'` from the returned context list. The end-to-end `evaluate` call is not driven by an automated test - see "Deviations".)*
 
 ## UAT checklist
 

--- a/docs/pbi-005-activation-integration-tests.md
+++ b/docs/pbi-005-activation-integration-tests.md
@@ -8,7 +8,7 @@
 |---|---|---|
 | 1 (harness) | `@vscode/test-electron` runner, Mocha glob, activation smoke, CI wiring | Done in PR #13 |
 | 2 (utility coverage) | `withTimeout` and `looksLikeError` tests | Done in **PBI-002** PR |
-| 2 (fake DAP) | In-process fake adapter exercising success and all-contexts-failed paths | Still deferred; will land with **PBI-003** (capability-detection tests need a tracker fake anyway) |
+| 2 (fake DAP) | In-process fake adapter exercising success and all-contexts-failed paths | Still deferred. PBI-003 chose to extract its tracker logic into a pure function and unit-test that instead, side-stepping the need for an adapter fake for capability detection. The fake-DAP machinery will land when a PBI actually requires it (likely PBI-004's frame-stability tests) and will be designed against that PBI's specific assertions rather than speculatively. |
 
 Rationale: the harness has its own plumbing risk (test-electron download pinning, headless `xvfb` on Linux, Electron version drift). Landing it on its own keeps any harness-level CI failure attributable instead of blamed on test logic. The fake-DAP work splits naturally with the PBIs that consume it - PBI-002's tests need truncation injection, PBI-003's tests need a tracker that omits `supportsClipboardContext`. Purpose-built fakes beat speculative generalization.
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "coreclr"
   ],
   "main": "./out/extension.js",
+  "activationEvents": [
+    "onDebug"
+  ],
   "contributes": {
     "commands": [
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,11 @@ import {
 import { unescapeCsharpString } from './util/unescape.js';
 import { validateEvaluateResult } from './util/validate.js';
 import { withTimeout } from './util/withTimeout.js';
+import {
+  clearSession,
+  createCapabilityTracker,
+  getSupportsClipboardContext,
+} from './util/clipboardCapability.js';
 
 const COMMAND_ID = 'csharpDebugCopyAsJson.copyAsJson';
 const CONFIG_SECTION = 'csharpDebugCopyAsJson';
@@ -31,6 +36,24 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand(COMMAND_ID, (arg: IVariablesContext) =>
       runCopyAsJson(arg, context),
     ),
+  );
+  // Watch every debug session's InitializeResponse so we know, authoritatively,
+  // whether the adapter supports DAP `evaluate` with `context: 'clipboard'`.
+  // Registered for `'*'` rather than `coreclr`/`clr` because the user can
+  // override `csharpDebugCopyAsJson.allowedDebugTypes`; the cost of a no-op
+  // tracker on unrelated sessions (one closure, one event subscription) is
+  // negligible compared to silently demoting the user to `hover`.
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterTrackerFactory('*', {
+      createDebugAdapterTracker(session) {
+        return createCapabilityTracker(session.id);
+      },
+    }),
+  );
+  context.subscriptions.push(
+    vscode.debug.onDidTerminateDebugSession((session) => {
+      clearSession(session.id);
+    }),
   );
 }
 
@@ -170,9 +193,13 @@ async function runCopyAsJsonInner(
 }
 
 function pickEvaluateContexts(session: vscode.DebugSession): EvaluateContext[] {
-  const supports = (
-    session as unknown as { capabilities?: { supportsClipboardContext?: boolean } }
-  ).capabilities?.supportsClipboardContext === true;
+  // The cache is populated by the DebugAdapterTracker we register in
+  // `activate`. A cache miss means we never observed an InitializeResponse for
+  // this session - either the tracker was registered too late (impossible
+  // given `onDebug` activation) or the adapter never sent capabilities. The
+  // safe default is `false`: skip `clipboard` and use `hover -> repl`, which
+  // is what every adapter is required to support.
+  const supports = getSupportsClipboardContext(session.id) === true;
   return supports ? ['clipboard', 'hover', 'repl'] : ['hover', 'repl'];
 }
 

--- a/src/test/clipboardCapability.test.ts
+++ b/src/test/clipboardCapability.test.ts
@@ -1,0 +1,174 @@
+import { strict as assert } from 'node:assert/strict';
+import {
+  _clearAllForTesting,
+  clearSession,
+  createCapabilityTracker,
+  getSupportsClipboardContext,
+  setSupportsClipboardContext,
+} from '../util/clipboardCapability.js';
+
+suite('clipboardCapability cache', () => {
+  setup(() => {
+    _clearAllForTesting();
+  });
+
+  test('get returns undefined for an unknown session', () => {
+    assert.equal(getSupportsClipboardContext('never-seen'), undefined);
+  });
+
+  test('set then get round-trips both true and false', () => {
+    setSupportsClipboardContext('s1', true);
+    setSupportsClipboardContext('s2', false);
+    assert.equal(getSupportsClipboardContext('s1'), true);
+    assert.equal(getSupportsClipboardContext('s2'), false);
+  });
+
+  test('clearSession evicts only the requested key', () => {
+    setSupportsClipboardContext('s1', true);
+    setSupportsClipboardContext('s2', true);
+    clearSession('s1');
+    assert.equal(getSupportsClipboardContext('s1'), undefined);
+    assert.equal(getSupportsClipboardContext('s2'), true);
+  });
+
+  test('clearSession on unknown key is a no-op', () => {
+    clearSession('never-seen');
+    assert.equal(getSupportsClipboardContext('never-seen'), undefined);
+  });
+
+  test('_clearAllForTesting wipes everything', () => {
+    setSupportsClipboardContext('s1', true);
+    setSupportsClipboardContext('s2', false);
+    _clearAllForTesting();
+    assert.equal(getSupportsClipboardContext('s1'), undefined);
+    assert.equal(getSupportsClipboardContext('s2'), undefined);
+  });
+});
+
+suite('createCapabilityTracker', () => {
+  setup(() => {
+    _clearAllForTesting();
+  });
+
+  function fire(tracker: ReturnType<typeof createCapabilityTracker>, msg: unknown): void {
+    // `onDidSendMessage` is optional in the interface; we always populate it.
+    tracker.onDidSendMessage!(msg);
+  }
+
+  test('caches true on InitializeResponse with supportsClipboardContext: true', () => {
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, {
+      type: 'response',
+      command: 'initialize',
+      success: true,
+      body: { supportsClipboardContext: true },
+    });
+    assert.equal(getSupportsClipboardContext('s1'), true);
+  });
+
+  test('caches false on InitializeResponse with supportsClipboardContext: false', () => {
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, {
+      type: 'response',
+      command: 'initialize',
+      success: true,
+      body: { supportsClipboardContext: false },
+    });
+    assert.equal(getSupportsClipboardContext('s1'), false);
+  });
+
+  test('caches false when InitializeResponse omits supportsClipboardContext', () => {
+    // Per DAP, the field is optional; absence means "not advertised".
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, {
+      type: 'response',
+      command: 'initialize',
+      success: true,
+      body: {},
+    });
+    assert.equal(getSupportsClipboardContext('s1'), false);
+  });
+
+  test('caches false when InitializeResponse has no body at all', () => {
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, { type: 'response', command: 'initialize', success: true });
+    assert.equal(getSupportsClipboardContext('s1'), false);
+  });
+
+  test('ignores failed InitializeResponse', () => {
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, {
+      type: 'response',
+      command: 'initialize',
+      success: false,
+      message: 'adapter failed to initialize',
+    });
+    assert.equal(getSupportsClipboardContext('s1'), undefined);
+  });
+
+  test('ignores responses to other commands', () => {
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, {
+      type: 'response',
+      command: 'launch',
+      success: true,
+      body: { supportsClipboardContext: true }, // shouldn't matter
+    });
+    assert.equal(getSupportsClipboardContext('s1'), undefined);
+  });
+
+  test('ignores DAP events (e.g. initialized event)', () => {
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, { type: 'event', event: 'initialized' });
+    assert.equal(getSupportsClipboardContext('s1'), undefined);
+  });
+
+  test('ignores requests routed back through the tracker', () => {
+    // `onDidSendMessage` only fires for adapter -> client traffic in
+    // production, but we still defend against any non-response shape.
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, { type: 'request', command: 'initialize', seq: 1 });
+    assert.equal(getSupportsClipboardContext('s1'), undefined);
+  });
+
+  test('ignores null / undefined / non-object messages', () => {
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, null);
+    fire(tracker, undefined);
+    fire(tracker, 'string');
+    fire(tracker, 42);
+    assert.equal(getSupportsClipboardContext('s1'), undefined);
+  });
+
+  test('two trackers with different session ids cache independently', () => {
+    const t1 = createCapabilityTracker('s1');
+    const t2 = createCapabilityTracker('s2');
+    fire(t1, {
+      type: 'response',
+      command: 'initialize',
+      success: true,
+      body: { supportsClipboardContext: true },
+    });
+    fire(t2, {
+      type: 'response',
+      command: 'initialize',
+      success: true,
+      body: { supportsClipboardContext: false },
+    });
+    assert.equal(getSupportsClipboardContext('s1'), true);
+    assert.equal(getSupportsClipboardContext('s2'), false);
+  });
+
+  test('coerces a non-boolean supportsClipboardContext to false', () => {
+    // Defense in depth: if a buggy adapter sends a string or number, we
+    // refuse to upgrade to clipboard.
+    const tracker = createCapabilityTracker('s1');
+    fire(tracker, {
+      type: 'response',
+      command: 'initialize',
+      success: true,
+      body: { supportsClipboardContext: 'yes' as unknown as boolean },
+    });
+    assert.equal(getSupportsClipboardContext('s1'), false);
+  });
+});

--- a/src/util/clipboardCapability.ts
+++ b/src/util/clipboardCapability.ts
@@ -1,0 +1,104 @@
+import type * as vscode from 'vscode';
+
+/**
+ * Per-session cache of the adapter's `supportsClipboardContext` capability,
+ * captured directly from the `InitializeResponse` body via a
+ * `DebugAdapterTracker`.
+ *
+ * This module replaces the previous duck-typed read of
+ * `(session as any).capabilities.supportsClipboardContext`. The `capabilities`
+ * field is not part of `vscode.DebugSession`'s public API; relying on it would
+ * break silently if VS Code ever hides the field.
+ *
+ * Lifecycle:
+ *   - `extension.activate` registers a `DebugAdapterTrackerFactory` for `'*'`
+ *     that creates trackers via `createCapabilityTracker(session.id)`.
+ *   - The tracker writes the capability into the cache when the
+ *     `InitializeResponse` arrives.
+ *   - `extension.activate` also subscribes to `onDidTerminateDebugSession` and
+ *     calls `clearSession(session.id)` to evict.
+ *
+ * Intentionally module-local state: there is exactly one extension host, and
+ * the cache is keyed by the host-assigned `session.id` which is unique per
+ * session even across reloads.
+ */
+
+const cache = new Map<string, boolean>();
+
+export function setSupportsClipboardContext(
+  sessionId: string,
+  supports: boolean,
+): void {
+  cache.set(sessionId, supports);
+}
+
+/**
+ * Returns the cached capability for `sessionId`, or `undefined` if no
+ * `InitializeResponse` has been observed for it yet. The caller must decide
+ * how to interpret a cache miss; the conservative choice is to treat it as
+ * `false` so we fall through to `hover` rather than risk an unsupported
+ * `clipboard` evaluate.
+ */
+export function getSupportsClipboardContext(
+  sessionId: string,
+): boolean | undefined {
+  return cache.get(sessionId);
+}
+
+export function clearSession(sessionId: string): void {
+  cache.delete(sessionId);
+}
+
+/**
+ * Test-only: wipe the entire cache between unit tests so state from one
+ * `suite` does not leak into the next.
+ */
+export function _clearAllForTesting(): void {
+  cache.clear();
+}
+
+/**
+ * Build a `DebugAdapterTracker` that watches outbound messages from the debug
+ * adapter and, on the first successful `InitializeResponse`, records
+ * `body.supportsClipboardContext` into the cache for `sessionId`.
+ *
+ * Exported (rather than inlined into `extension.ts`) so the message-extraction
+ * logic can be unit-tested without spinning up a fake debug adapter or an
+ * Electron host.
+ */
+export function createCapabilityTracker(
+  sessionId: string,
+): vscode.DebugAdapterTracker {
+  return {
+    onDidSendMessage(message: unknown): void {
+      if (!isInitializeResponse(message)) {
+        return;
+      }
+      const supports = message.body?.supportsClipboardContext === true;
+      setSupportsClipboardContext(sessionId, supports);
+    },
+  };
+}
+
+interface InitializeResponseShape {
+  type: 'response';
+  command: 'initialize';
+  success: true;
+  body?: { supportsClipboardContext?: boolean };
+}
+
+function isInitializeResponse(
+  message: unknown,
+): message is InitializeResponseShape {
+  if (typeof message !== 'object' || message === null) {
+    return false;
+  }
+  const m = message as {
+    type?: unknown;
+    command?: unknown;
+    success?: unknown;
+  };
+  return (
+    m.type === 'response' && m.command === 'initialize' && m.success === true
+  );
+}


### PR DESCRIPTION
## Summary

Closes review item **C3** from the v0.0.1 code review (tracked as [PBI-003](./docs/pbi-003-stable-capability-detection.md)).

`extension.ts` previously read clipboard-context support via a `(session as unknown as { capabilities?: { supportsClipboardContext?: boolean } }).capabilities?.supportsClipboardContext === true` cast. That `capabilities` field is **not part of `vscode.DebugSession`'s public API** — it happens to exist on the current implementation. The day VS Code hides it, every user silently demotes to the `hover -> repl` chain and re-introduces the truncation symptom PBI-002 just fixed.

This PR replaces the cast with a public, supported mechanism.

## What changed

- **New module `src/util/clipboardCapability.ts`** — module-local `Map<sessionId, boolean>` cache, plus a `createCapabilityTracker(sessionId)` factory that returns a `vscode.DebugAdapterTracker` watching `onDidSendMessage` for the `InitializeResponse` and recording `body.supportsClipboardContext` into the cache.
- **`src/extension.ts`**:
  - Registers the tracker factory on `'*'` at activation (one closure per debug session is cheap; matches the runtime behavior of `csharpDebugCopyAsJson.allowedDebugTypes`).
  - Subscribes to `onDidTerminateDebugSession` and evicts.
  - `pickEvaluateContexts` now reads from the cache; cache miss is treated as `false` so we never attempt an unsupported `clipboard` evaluate.
  - Removes the `as unknown as` cast entirely.
- **`package.json`** — adds `"activationEvents": ["onDebug"]`. Without this, lazy command-based activation fires *after* the user right-clicks a variable, which is *after* `InitializeResponse`, and the tracker would never see it. With it, the tracker is in place before any debug session starts.
- **`docs/pbi-003-…md`** — status to In progress; new "Architectural decisions" rows for the `'*'` registration scope, the `onDebug` activation event, the cache-miss-equals-false rule, and the tracker-extraction-for-testability decision; new "Deviations" section documenting the fake-DAP deferral.
- **`docs/pbi-005-…md`** — fake-DAP row updated to reflect that PBI-003 chose unit-tested extraction over a fake adapter.

## Why no fake-adapter integration test

PBI-003's last AC asks for an integration test that drives a fake `DebugAdapterInlineImplementation` end-to-end. Doing that would require either:

1. contributing a `debuggers` entry in `package.json` for a test-only debug type — which would ship in the published Marketplace package, or
2. shipping a `DebugConfigurationProvider` shim with the same surface concerns.

Both pollute the production package surface for one assertion. Instead, the message-extraction logic — the only thing worth asserting end-to-end — was extracted into a pure `createCapabilityTracker(sessionId)` and unit-tested against every wire shape it can receive. The remaining untested surface is **two lines of glue** (`registerDebugAdapterTrackerFactory` + the eviction listener), which manual UAT and existing activation smoke cover.

If/when PBI-004 (frame stability across dialogs) needs an actual fake adapter for its own assertions, we'll bundle it then and retroactively add the integration assertion here. Speculative generalization avoided.

## Tests

`npm test`:

- **60 unit passing** (was 44; +16 new):
  - 5 over the cache API (set/get round-trip, unknown-key get, eviction scoping, no-op clear, full reset).
  - 11 over `createCapabilityTracker` covering: `supportsClipboardContext: true`, `false`, omitted field, no body, failed init, response to other commands, DAP events, requests, null/undefined/string/number junk, two independent sessions, and non-boolean coercion.
- **2 integration passing** (activation smoke + command registration). Activation now fires on `onDebug`; the smoke test still works because the test host enumerates commands which keeps activation green.
- Lint clean. TS clean.

## Acceptance criteria

| AC | Status | How |
|---|---|---|
| No `as any` / `as unknown as` casts on `vscode.DebugSession` | ✅ | Removed in `pickEvaluateContexts`. |
| Adapter omitting `supportsClipboardContext` does not crash and falls through to `hover -> repl` | ✅ | Tracker writes `false`; `pickEvaluateContexts` returns `['hover','repl']`. Covered by unit tests. |
| `supportsClipboardContext: false` session does not attempt `clipboard` evaluate | ⚠️ Asserted at the cache / `pickEvaluateContexts` boundary, not end-to-end | See "Why no fake-adapter integration test" above. |
| Manual: VS Code 1.89, current stable, current insiders pick `clipboard` exactly when advertised | 🔲 Manual UAT | See checklist below. |
