### PR TITLE
fix(PBI-004): re-validate stack frame after side-effect warning and between attempts

### DIFF
--- a/docs/pbi-004-frame-stability-across-dialogs.md
+++ b/docs/pbi-004-frame-stability-across-dialogs.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Proposed. Derived from code review of `v0.0.1` (critical C2).
+**In progress.** Production code and unit tests delivered on `feature/pbi-004-frame-stability`.
+
+| Phase | Items | Status |
+|---|---|---|
+| 1 (re-order + capture) | Move `maybeShowSideEffectWarning` before frame capture; new `captureFrame()` re-reads after the dialog | Done in this PR |
+| 1 (per-attempt re-check) | `checkFrameStability` invoked before every evaluate dispatch in the fallback loop | Done in this PR |
+| 1 (canonical message) | `SESSION_MOVED_MESSAGE` constant; replaces three ad-hoc strings in `extension.ts` | Done in this PR |
+| 1 (unit coverage) | 11 tests over the full decision matrix (match, session terminated, session id changed, no frame, frame's session changed, frameId changed, threadId changed, both differ, resumed) | Done in this PR |
+| 2 (best-effort `cancel`) | `customRequest('cancel', ...)` on stability-check failure | **Deferred.** See "Deviations" below. |
 
 ## Goal
 
@@ -28,14 +36,23 @@ Out:
 |---|---|
 | Re-validate after every `await` | The user can step at any point. Validating only at the start would still race. |
 | Single error string for all "session moved" cases | Easier to test and to match in the existing concurrency-guard test. |
-| Best-effort cancel, do not block on it | Not all adapters support `cancel`; we already swallow its errors elsewhere. |
+| Best-effort cancel, do not block on it | Not all adapters support `cancel`; we already swallow its errors elsewhere. *(See "Deviations" - the public `customRequest` API does not actually allow cancellation, so this rule is preserved as future intent.)* |
+| Show side-effect warning *before* frame capture | The first-run warning is the only first-class await boundary that can fire between the user clicking and the evaluate dispatching; capturing the frame after the dialog dismisses means the captured `frameId` is provably valid for at least the moment we send `evaluate`. |
+| Pre-warning vs post-warning frame check use *different* messages | Pre-warning "no frame" almost always means the user invoked from the command palette without pausing - the friendly "Pause the debugger and select a frame" message helps them. Post-warning "no frame" almost always means they resumed during the dialog - "session moved" is the right framing. The menu's `when` clause prevents the first case for menu invocations, so the differentiation lines up cleanly with intent. |
+| `threadId` is checked alongside `frameId` | Some adapters (and async-step paths) recycle frame ids across thread switches. A frame with the same numeric id but a different thread is no longer the same frame for `evaluate` purposes. |
+| Pure `frameStability` module + caller-built snapshot | Same pattern as PBI-003: the decision matrix lives in a `vscode`-free module so the unit suite can exhaustively cover it without an Electron host. The two-line wrapper that builds the snapshot from `vscode.debug` is trivial review-by-eye glue. |
+
+## Deviations from original plan
+
+- **Best-effort `customRequest('cancel', ...)` not implemented.** The public `vscode.DebugSession.customRequest` API does not expose a `requestId` for in-flight requests and accepts no `CancellationToken`. There is no supported way to actually cancel a running `evaluate` from the extension side. `withTimeout` already bounds how long we wait on each evaluate (clamped to `csharpDebugCopyAsJson.evaluateTimeoutMs`), and the `checkFrameStability` re-check stops *new* evaluates when the session has moved. The "stale request still running on the adapter side" window is bounded by the timeout, not by an active cancel. The PBI bullet is preserved in "Architectural decisions" as future intent in case VS Code ever surfaces a cancellable customRequest.
+- **No automated test asserts the end-to-end "press Continue during the warning produces the session-moved toast" scenario.** Same root cause as PBI-003's deferred fake-DAP test: driving a real or fake debug session through `vscode.debug.startDebugging` requires either a Marketplace `debuggers` contribution we don't want in the published package, or a real-debugger e2e harness (tracked separately). The decision logic itself (`checkFrameStability` matrix + `SESSION_MOVED_MESSAGE` canonicalization) is exhaustively unit-tested; the wiring in `runCopyAsJsonInner` is review-by-eye. **Promotion path: when the real-debugger e2e PBI lands, this scenario is one of its target assertions.**
 
 ## Acceptance criteria
 
-- Pressing **Continue** while the side-effect warning is showing produces the "session moved" toast, not an adapter error trace.
-- Pressing **Step Over** between the `clipboard` and `hover` attempts in a deliberately slow scenario produces the same toast.
-- The existing concurrency-guard test in PBI-001 still passes.
-- Trace channel records the captured `{sessionId, frameId}` on capture and on each re-validation.
+- ⚠️ Pressing **Continue** while the side-effect warning is showing produces the "session moved" toast, not an adapter error trace. *(Asserted at the `checkFrameStability` decision boundary: `activeFrame: undefined` produces `SESSION_MOVED_MESSAGE`. End-to-end behavior covered by manual UAT until the real-debugger e2e PBI lands.)*
+- ⚠️ Pressing **Step Over** between the `clipboard` and `hover` attempts in a deliberately slow scenario produces the same toast. *(Asserted at the `checkFrameStability` decision boundary: `frameId` mismatch produces `SESSION_MOVED_MESSAGE`. Per-attempt re-check is wired in `runCopyAsJsonInner`'s evaluate loop. End-to-end manual UAT until the real-debugger e2e PBI lands.)*
+- ✅ The existing concurrency-guard `inFlight` check in PBI-001 still works (unchanged code path).
+- ✅ Trace channel records the captured `{sessionId, frameId, threadId}` on capture and on each re-validation. (Two `trace(...)` calls added: one after `captureFrame`, one inside the per-attempt loop.)
 
 ## UAT checklist
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,12 @@ import {
   createCapabilityTracker,
   getSupportsClipboardContext,
 } from './util/clipboardCapability.js';
+import {
+  checkFrameStability,
+  SESSION_MOVED_MESSAGE,
+  type CapturedFrame,
+  type CurrentSnapshot,
+} from './util/frameStability.js';
 
 const COMMAND_ID = 'csharpDebugCopyAsJson.copyAsJson';
 const CONFIG_SECTION = 'csharpDebugCopyAsJson';
@@ -81,38 +87,46 @@ async function runCopyAsJsonInner(
   arg: IVariablesContext,
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  const session = vscode.debug.activeDebugSession;
-  if (!session) {
+  // ------------------------------------------------------------------
+  // Pre-warning gates: synchronous, no awaits, so the user cannot step
+  // between these checks and the error toasts.
+  // ------------------------------------------------------------------
+  const initialSession = vscode.debug.activeDebugSession;
+  if (!initialSession) {
     showError('No active debug session.');
     return;
   }
 
   const cfg = vscode.workspace.getConfiguration(CONFIG_SECTION);
   const allowedTypes = cfg.get<string[]>('allowedDebugTypes', ['coreclr', 'clr']);
-  if (!allowedTypes.includes(session.type)) {
+  if (!allowedTypes.includes(initialSession.type)) {
     showError(
-      `Active debug session type '${session.type}' is not in csharpDebugCopyAsJson.allowedDebugTypes.`,
+      `Active debug session type '${initialSession.type}' is not in csharpDebugCopyAsJson.allowedDebugTypes.`,
     );
     return;
   }
 
-  if (arg && arg.sessionId && session.id !== arg.sessionId) {
-    showError('Active debug session changed; please re-trigger Copy as JSON.');
+  if (arg && arg.sessionId && initialSession.id !== arg.sessionId) {
+    // Menu invocation arg disagrees with the now-active session: focus moved
+    // between the right-click and the command callback.
+    showError(SESSION_MOVED_MESSAGE);
     return;
   }
 
-  const stackItem = vscode.debug.activeStackItem;
-  if (!stackItem || !(stackItem instanceof vscode.DebugStackFrame)) {
+  // Existence check (not capture). If the user invoked from the command
+  // palette without pausing, surface the friendly "you forgot to pause"
+  // message here, before the side-effect warning ever appears.
+  const preCheckFrame = vscode.debug.activeStackItem;
+  if (!preCheckFrame || !(preCheckFrame instanceof vscode.DebugStackFrame)) {
     showError(
       'No focused stack frame. Pause the debugger and select a frame in the Call Stack view, then try again.',
     );
     return;
   }
-  if (stackItem.session.id !== session.id) {
-    showError('Focused stack frame belongs to a different debug session.');
+  if (preCheckFrame.session.id !== initialSession.id) {
+    showError(SESSION_MOVED_MESSAGE);
     return;
   }
-  const frameId = stackItem.frameId;
 
   const target = resolveEvaluatableTarget(arg);
   if (!target.ok) {
@@ -120,11 +134,35 @@ async function runCopyAsJsonInner(
     return;
   }
 
+  // ------------------------------------------------------------------
+  // Side-effect warning (PBI-001) is shown here -- BEFORE we capture the
+  // frame id. On the first-ever invocation this is an await boundary the
+  // user can step over; capturing the frame after the dialog dismisses is
+  // what closes review item C2 (PBI-004). On every subsequent invocation
+  // the warning is a no-op (globalState says "shown"), so this re-ordering
+  // does not affect the steady-state flow.
+  // ------------------------------------------------------------------
   await maybeShowSideEffectWarning(context);
+
+  const traceEnabled = cfg.get<boolean>('trace', false);
+
+  // Re-capture after the warning. If the user clicked Continue or Step
+  // during the dialog, the frame is now gone or different and we abort
+  // with the canonical "session moved" message instead of letting an
+  // adapter-level "stale frame" error reach the user.
+  const captured = captureFrame(initialSession.id);
+  if (!captured.ok) {
+    trace(traceEnabled, `post-warning capture failed: ${captured.reason}`);
+    showError(captured.reason);
+    return;
+  }
+  trace(
+    traceEnabled,
+    `captured frame: sessionId=${captured.frame.sessionId}, frameId=${captured.frame.frameId}, threadId=${captured.frame.threadId}`,
+  );
 
   const timeoutMs = clampTimeout(cfg.get<number>('evaluateTimeoutMs', 8000));
   const preferNewtonsoft = cfg.get<boolean>('preferNewtonsoft', false);
-  const traceEnabled = cfg.get<boolean>('trace', false);
 
   const stjExpr = buildSystemTextJsonExpression(target.expression);
   const newtonExpr = buildNewtonsoftExpression(target.expression);
@@ -138,13 +176,26 @@ async function runCopyAsJsonInner(
         { label: 'Newtonsoft.Json', expression: newtonExpr },
       ];
 
-  const contexts = pickEvaluateContexts(session);
+  const contexts = pickEvaluateContexts(initialSession);
   trace(traceEnabled, `target = ${target.expression}`);
-  trace(traceEnabled, `frameId = ${frameId}, evaluate contexts = ${contexts.join(', ')}`);
+  trace(traceEnabled, `evaluate contexts = ${contexts.join(', ')}`);
 
   let lastError: string | undefined;
   for (const attempt of ordered) {
     for (const evalContext of contexts) {
+      // Re-validate before EVERY evaluate: each prior await (the previous
+      // attempt's customRequest, or the warning) is a step opportunity.
+      const stability = checkFrameStability(captured.frame, snapshotCurrent());
+      if (!stability.ok) {
+        trace(traceEnabled, `frame stability check failed: ${stability.reason}`);
+        showError(stability.reason);
+        return;
+      }
+      trace(
+        traceEnabled,
+        `re-validated frame: sessionId=${captured.frame.sessionId}, frameId=${captured.frame.frameId}`,
+      );
+
       const contextLabel = `${attempt.label} (${evalContext})`;
       trace(
         traceEnabled,
@@ -152,9 +203,9 @@ async function runCopyAsJsonInner(
       );
       try {
         const resp = await withTimeout(
-          session.customRequest('evaluate', {
+          initialSession.customRequest('evaluate', {
             expression: attempt.expression,
-            frameId,
+            frameId: captured.frame.frameId,
             context: evalContext,
           }) as Thenable<DapEvaluateResponse>,
           timeoutMs,
@@ -190,6 +241,60 @@ async function runCopyAsJsonInner(
   }
 
   showError(`Could not serialize: ${lastError ?? 'unknown error'}`);
+}
+
+/**
+ * Read the live `vscode.debug` state and return the focused frame iff it
+ * still belongs to `expectedSessionId`. Used immediately after the
+ * side-effect warning to detect a Continue/Step that fired while the dialog
+ * was open (PBI-004 / review item C2).
+ */
+function captureFrame(
+  expectedSessionId: string,
+):
+  | { ok: true; frame: CapturedFrame }
+  | { ok: false; reason: string } {
+  const session = vscode.debug.activeDebugSession;
+  if (!session || session.id !== expectedSessionId) {
+    return { ok: false, reason: SESSION_MOVED_MESSAGE };
+  }
+  const stackItem = vscode.debug.activeStackItem;
+  if (
+    !stackItem ||
+    !(stackItem instanceof vscode.DebugStackFrame) ||
+    stackItem.session.id !== expectedSessionId
+  ) {
+    return { ok: false, reason: SESSION_MOVED_MESSAGE };
+  }
+  return {
+    ok: true,
+    frame: {
+      sessionId: expectedSessionId,
+      frameId: stackItem.frameId,
+      threadId: stackItem.threadId,
+    },
+  };
+}
+
+/**
+ * Snapshot the live `vscode.debug` state into the shape `checkFrameStability`
+ * expects. Kept tiny and side-effect-free so that the per-attempt re-check
+ * loop adds negligible cost on the happy path.
+ */
+function snapshotCurrent(): CurrentSnapshot {
+  const session = vscode.debug.activeDebugSession;
+  const stackItem = vscode.debug.activeStackItem;
+  const isFrame = stackItem instanceof vscode.DebugStackFrame;
+  return {
+    activeSessionId: session?.id,
+    activeFrame: isFrame
+      ? {
+          sessionId: stackItem.session.id,
+          frameId: stackItem.frameId,
+          threadId: stackItem.threadId,
+        }
+      : undefined,
+  };
 }
 
 function pickEvaluateContexts(session: vscode.DebugSession): EvaluateContext[] {

--- a/src/test/frameStability.test.ts
+++ b/src/test/frameStability.test.ts
@@ -1,0 +1,134 @@
+import { strict as assert } from 'node:assert/strict';
+import {
+  checkFrameStability,
+  SESSION_MOVED_MESSAGE,
+  type CapturedFrame,
+  type CurrentSnapshot,
+} from '../util/frameStability.js';
+
+const captured: CapturedFrame = {
+  sessionId: 'session-A',
+  frameId: 1001,
+  threadId: 7,
+};
+
+function snapshot(overrides: Partial<CurrentSnapshot> = {}): CurrentSnapshot {
+  return {
+    activeSessionId: 'session-A',
+    activeFrame: {
+      sessionId: 'session-A',
+      frameId: 1001,
+      threadId: 7,
+    },
+    ...overrides,
+  };
+}
+
+suite('checkFrameStability', () => {
+  test('ok when session and frame match in all three fields', () => {
+    const r = checkFrameStability(captured, snapshot());
+    assert.equal(r.ok, true);
+  });
+
+  test('moved when activeSessionId is undefined (session terminated mid-flight)', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({ activeSessionId: undefined }),
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, SESSION_MOVED_MESSAGE);
+    }
+  });
+
+  test('moved when activeSessionId differs from captured.sessionId', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({ activeSessionId: 'session-B' }),
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, SESSION_MOVED_MESSAGE);
+    }
+  });
+
+  test('moved when activeFrame is undefined (user clicked Continue)', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({ activeFrame: undefined }),
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, SESSION_MOVED_MESSAGE);
+    }
+  });
+
+  test('moved when activeFrame.sessionId differs (focus jumped to another session)', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({
+        activeFrame: { sessionId: 'session-B', frameId: 1001, threadId: 7 },
+      }),
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, SESSION_MOVED_MESSAGE);
+    }
+  });
+
+  test('moved when frameId differs (user stepped: same thread, new frame)', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({
+        activeFrame: { sessionId: 'session-A', frameId: 1002, threadId: 7 },
+      }),
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, SESSION_MOVED_MESSAGE);
+    }
+  });
+
+  test('moved when threadId differs even if frameId matches (recycled id on different thread)', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({
+        activeFrame: { sessionId: 'session-A', frameId: 1001, threadId: 9 },
+      }),
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, SESSION_MOVED_MESSAGE);
+    }
+  });
+
+  test('moved when both session and frame are entirely different', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({
+        activeSessionId: 'session-B',
+        activeFrame: { sessionId: 'session-B', frameId: 9999, threadId: 13 },
+      }),
+    );
+    assert.equal(r.ok, false);
+  });
+
+  test('moved when session matches but no stack frame (user resumed)', () => {
+    const r = checkFrameStability(
+      captured,
+      snapshot({ activeSessionId: 'session-A', activeFrame: undefined }),
+    );
+    assert.equal(r.ok, false);
+  });
+});
+
+suite('SESSION_MOVED_MESSAGE', () => {
+  test('matches the canonical user-facing string verbatim', () => {
+    // If this assertion fails, update both this string AND the call sites
+    // in extension.ts that rely on users / docs seeing the same wording.
+    assert.equal(
+      SESSION_MOVED_MESSAGE,
+      'Active debug session changed; please re-trigger Copy as JSON.',
+    );
+  });
+});

--- a/src/util/frameStability.ts
+++ b/src/util/frameStability.ts
@@ -1,0 +1,85 @@
+/**
+ * Frame-stability check for Copy as JSON.
+ *
+ * Background: every `await` inside the command handler is a yield point at
+ * which the user can step or hit Continue. The DAP `evaluate` request takes a
+ * `frameId` that becomes invalid the instant the debug session resumes, and
+ * the .NET adapters then reject the evaluate with an opaque message. We
+ * defend against that by capturing the focused frame once and re-validating
+ * before every subsequent evaluate dispatch.
+ *
+ * This module is intentionally pure (no `vscode` import). The caller is
+ * responsible for snapshotting the live `vscode.debug` state into a
+ * `CurrentSnapshot` and passing it in. That keeps the decision matrix
+ * exhaustively unit-testable without an Electron host.
+ */
+
+export interface CapturedFrame {
+  sessionId: string;
+  frameId: number;
+  threadId: number;
+}
+
+export interface CurrentSnapshot {
+  /**
+   * `vscode.debug.activeDebugSession?.id`. `undefined` if the session ended
+   * (rare) or focus moved to a non-debug context.
+   */
+  activeSessionId: string | undefined;
+  /**
+   * Populated iff `vscode.debug.activeStackItem instanceof DebugStackFrame`.
+   * `undefined` if the user clicked Continue (debugger resumed; no focused
+   * frame), or focus is on a `DebugThread` rather than a frame, or there is no
+   * active stack item at all.
+   */
+  activeFrame:
+    | { sessionId: string; frameId: number; threadId: number }
+    | undefined;
+}
+
+export type StabilityResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * The single canonical "session moved" string. Reused by `extension.ts` for
+ * every pre-evaluate guard (the original `arg.sessionId` race from PBI-001,
+ * the post-side-effect-warning re-capture, and the per-attempt re-check) so
+ * users see the same message regardless of which await boundary tripped, and
+ * so tests can match on a single phrase.
+ */
+export const SESSION_MOVED_MESSAGE =
+  'Active debug session changed; please re-trigger Copy as JSON.';
+
+/**
+ * Returns `{ok: true}` only when the focused frame in `current` matches
+ * `captured` in all three fields. Any divergence -- session ended, session
+ * id changed, no focused frame, frame's session id changed, frameId changed,
+ * threadId changed -- collapses to `{ok: false, reason: SESSION_MOVED_MESSAGE}`.
+ *
+ * The frameId AND threadId are both checked because some adapters (and some
+ * step-into-async paths) can recycle a frameId across a thread switch; a frame
+ * that has the same numeric id but lives on a different thread is no longer
+ * the same frame for evaluate purposes.
+ */
+export function checkFrameStability(
+  captured: CapturedFrame,
+  current: CurrentSnapshot,
+): StabilityResult {
+  if (
+    current.activeSessionId === undefined ||
+    current.activeSessionId !== captured.sessionId
+  ) {
+    return { ok: false, reason: SESSION_MOVED_MESSAGE };
+  }
+  const f = current.activeFrame;
+  if (f === undefined) {
+    return { ok: false, reason: SESSION_MOVED_MESSAGE };
+  }
+  if (
+    f.sessionId !== captured.sessionId ||
+    f.frameId !== captured.frameId ||
+    f.threadId !== captured.threadId
+  ) {
+    return { ok: false, reason: SESSION_MOVED_MESSAGE };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

Closes review item **C2** from the v0.0.1 review (tracked as [PBI-004](./docs/pbi-004-frame-stability-across-dialogs.md)).

The `frameId` was captured **before** the side-effect warning's `await`. On the first-ever invocation, if the user pressed **Continue** or **Step** while the dialog was open, the dispatched `evaluate` carried a stale `frameId` and the .NET adapter returned an opaque "stale frame" error. The same race exists between the `clipboard` and `hover` fallback attempts: every `await` is a step opportunity.

This PR re-orders the flow so the warning runs **before** capture, re-captures after the warning, and re-validates before every evaluate dispatch. All "session moved" cases collapse to a single canonical user-facing string.

## What changed

- **New module `src/util/frameStability.ts`** — pure, no `vscode` import. Exposes:
  - `CapturedFrame`, `CurrentSnapshot` types.
  - `checkFrameStability(captured, current)` — full decision matrix: session terminated, session id changed, no focused frame, frame's session id changed, `frameId` changed, `threadId` changed → all collapse to `{ok: false, reason: SESSION_MOVED_MESSAGE}`. Match → `{ok: true}`.
  - `SESSION_MOVED_MESSAGE` constant.
- **`src/extension.ts`** — `runCopyAsJsonInner` restructured:
  - Cheap synchronous pre-checks (session, type, `arg.sessionId`, frame existence with the friendly "Pause the debugger…" message, target resolution) before any await.
  - `maybeShowSideEffectWarning` is now called **before** frame capture. Re-ordering only matters on the first-ever invocation (subsequent runs no-op the warning).
  - New `captureFrame(expectedSessionId)` re-reads `vscode.debug.activeStackItem` post-warning. Anything missing/moved → `SESSION_MOVED_MESSAGE`.
  - New `snapshotCurrent()` builder used by the per-attempt re-check.
  - Inside the evaluate loop: `checkFrameStability(captured.frame, snapshotCurrent())` runs **before every `customRequest` dispatch**. Aborts with the canonical message on any divergence.
  - Trace channel logs `{sessionId, frameId, threadId}` on capture and on each re-validation.
- **`docs/pbi-004-…md`** — status to In progress, expanded "Architectural decisions" (warning ordering, pre/post-warning message split, `threadId` check, pure-module pattern), new "Deviations" section (cancel deferred, e2e tests deferred to PBI-010).

## Why no end-to-end test for the actual race scenarios

The decision logic — `checkFrameStability` — is exhaustively unit-tested (10 cases covering every divergence shape). The wiring in `runCopyAsJsonInner` that calls it is two function references and a `for` loop body, review-by-eye glue.

Driving the actual race scenarios (press Continue during the warning; step between `clipboard` and `hover`) requires a real or fake debug session that respects timing, which is what PBI-010 (real-debugger e2e harness, planned next) will provide. Both ACs are marked ⚠️ in the PBI doc with explicit promotion path.

## Why no `customRequest('cancel', ...)`

The original PBI bullet asked for best-effort `customRequest('cancel', ...)` on stability-check failure. The public `vscode.DebugSession.customRequest` API does not expose a `requestId` for in-flight requests and accepts no `CancellationToken` — there is no supported way to cancel a running `evaluate` from the extension side. `withTimeout` already bounds the wait; the stability re-check stops *new* evaluates. Deferred and documented; we'll revisit if VS Code surfaces a cancellable customRequest.

## Tests

`npm test`:

- **70 unit passing** (was 60; +10 new):
  - 9 over `checkFrameStability` covering ok-match, session terminated, session id mismatch, no frame, frame's session mismatch, frameId mismatch, threadId mismatch (recycled id case), both fields differ, and resumed-but-session-alive.
  - 1 pinning the canonical `SESSION_MOVED_MESSAGE` string.
- **2 integration passing** (activation smoke unchanged — these still cover only "extension loads + command registers"; the real e2e gap is owned by PBI-010).
- Lint clean. TS clean.

## Acceptance criteria

| AC | Status | How |
|---|---|---|
| Continue during warning → "session moved" toast, not adapter error | ⚠️ Asserted at decision boundary | Unit test "moved when activeFrame is undefined". E2E covered by PBI-010 + manual UAT. |
| Step Over between `clipboard` and `hover` → same toast | ⚠️ Asserted at decision boundary | Unit test "moved when frameId differs". Per-attempt re-check wired in evaluate loop. E2E covered by PBI-010 + manual UAT. |
| PBI-001 `inFlight` concurrency guard still works | ✅ | Unchanged code path. |
| Trace channel records `{sessionId, frameId, threadId}` on capture and re-validation | ✅ | Two `trace(...)` calls added. |