### PR TITLE
feat!: real-time Copy as JSON via frame-scoped cache (PBI-011)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   # Keep this in sync with DEFAULT_VSCODE_VERSION in
   # src/test/integration/runIntegration.ts. The cache key below depends on it,
   # so bumping this value will invalidate the cache on the next run.
-  VSCODE_TEST_VERSION: 1.89.0
+  VSCODE_TEST_VERSION: 1.90.0
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
   # Keep in sync with DEFAULT_VSCODE_VERSION in
   # src/test/integration/runIntegration.ts and with VSCODE_TEST_VERSION
   # in .github/workflows/ci.yml. The cache key below depends on it.
-  VSCODE_TEST_VERSION: 1.89.0
+  VSCODE_TEST_VERSION: 1.90.0
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an icon (128x128 PNG).
 - Mirror the command on `debug/watch/context`.
 - Optional chunked retrieval for very large objects via `variablesReference` traversal.
+- PBI-006 user-visible polish (ref-struct refusal, codicon, centralized message strings, `noDebug` skip).
+
+## [0.2.0] - 2026-04-27
+
+### Breaking
+
+- **Engine floor bumped from `^1.89.0` to `^1.90.0`.** The cache invalidation in PBI-011 / C2 subscribes to `vscode.debug.onDidChangeActiveStackItem` at activation time, and that event (along with the `vscode.debug.activeStackItem` property used since PBI-004) is part of the `debugFocus` proposal that VS Code only finalized in 1.90.0 (microsoft/vscode#212190, May 2024). On 1.89.x the activation throws and the extension fails to load. The matching workflow-level `VSCODE_TEST_VERSION` and the `runIntegration.ts` `DEFAULT_VSCODE_VERSION` are bumped in lockstep so the activation-smoke gate continues to run against the actual floor. **Action required for users on VS Code 1.89.x: upgrade to 1.90.0 or later.** This also incidentally fixes a latent issue in 0.1.x where invoking **Copy as JSON** on a 1.89.x host would have thrown at command-time on the `vscode.debug.activeStackItem` read (the floor was advertised as 1.89 but the API only became stable in 1.90).
+
+### Changed
+
+- **Real-time re-copy via frame-scoped cache.** Re-copying the same variable on the same paused frame is now served from an in-memory cache keyed by `(sessionId, threadId, frameId, expression)`. No DAP round-trip, no extra side effects. The cache is invalidated on `onDidChangeActiveStackItem` (step / continue / Call Stack frame switch) and on `onDidTerminateDebugSession` (PBI-011 / C1, C2).
+- **Cancel-and-replace dispatch.** Clicking **Copy as JSON** while a previous evaluate is still in flight now cancels the previous via `CancellationTokenSource` and starts the new one. The "Copy as JSON is already running for the previous variable" toast is removed entirely. Last click wins the clipboard. (PBI-011 / C3.)
+- **Per-session winning-context memo.** The first DAP `evaluate` context (`clipboard` / `hover` / `repl`) that returns a parseable result for a session is tried first on subsequent invocations in that session; on session terminate the memo is cleared. Cuts cold-path latency for everything after the first variable. (PBI-011 / C4.)
+- **Non-blocking side-effect notice.** The first-use modal-ish information dialog is replaced by (a) a one-time disclosure line appended to the **Copy as JSON** output channel on first invocation per install (gated by the existing `globalState` key, so upgrading users who already dismissed the dialog do not see the disclosure again), and (b) a per-invocation transient status-bar reminder controllable by the new `csharpDebugCopyAsJson.showSideEffectReminder` setting. (PBI-011 / C5.)
+- **Status-bar dispatch feedback.** Every invocation immediately shows a `$(sync~spin) Copy as JSON…` status-bar message that is cleared on success, cache hit, failure, or cancel. Cache hits and evaluate successes show distinct success messages so the cache is observable. (PBI-011 / C6.)
+
+### Added
+
+- New setting `csharpDebugCopyAsJson.showSideEffectReminder` (default `true`).
+- New module `src/util/resultCache.ts` (`ResultCache` class) with full unit-test coverage for `put` / `get` / `clearThread` / `clearSession` / `clearAll`, including key-collision and overlapping-numeric-prefix edge cases.
+
+### Removed
+
+- The `inFlight` boolean and the `Copy as JSON is already running` information toast.
+- The `maybeShowSideEffectWarning` modal information dialog and the post-warning `captureFrame` re-validation step. With no awaitable dialog between target resolution and the evaluate loop, the captured frame is still re-validated per attempt by the existing `checkFrameStability` gate (PBI-004), which is unchanged.
 
 ## [0.1.1] - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/JadeEye21/vscode-csharp-copy-as-json/actions/workflows/ci.yml/badge.svg)](https://github.com/JadeEye21/vscode-csharp-copy-as-json/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![VS Code engine](https://img.shields.io/badge/vscode-%5E1.89.0-blue.svg)](https://code.visualstudio.com/updates/v1_89)
+[![VS Code engine](https://img.shields.io/badge/vscode-%5E1.90.0-blue.svg)](https://code.visualstudio.com/updates/v1_90)
 
 Right-click a variable in the VS Code **Variables** view during a C# / .NET debug session and copy it to the clipboard as pretty-printed JSON.
 
@@ -26,7 +26,9 @@ Until the extension is on the Marketplace, install it from a VSIX:
 3. Right-click the variable &rarr; **Copy as JSON**.
 4. Paste anywhere.
 
-The first time you use the command in a workspace you will see a one-time information message about side effects (see [Limitations](#limitations)).
+Re-copying the same variable on the same paused frame is served from a frame-scoped in-memory cache &mdash; no DAP round-trip, no extra side effects. The cache is invalidated whenever you step, continue, switch frames in the **Call Stack** view, or end the session. Clicking the command again while a previous evaluate is still in flight cancels the previous and starts the new one (last click wins).
+
+The first time you use the command on a fresh install, a one-time disclosure about side effects is appended to the **Copy as JSON** output channel (see [Limitations](#limitations)). Every subsequent invocation flashes a transient status-bar reminder that the command evaluates expressions in the debuggee process; you can mute that reminder via `csharpDebugCopyAsJson.showSideEffectReminder`.
 
 ## Settings
 
@@ -35,7 +37,8 @@ The first time you use the command in a workspace you will see a one-time inform
 | `csharpDebugCopyAsJson.allowedDebugTypes` | `["coreclr","clr"]` | Debug adapter types the runtime guard accepts. |
 | `csharpDebugCopyAsJson.evaluateTimeoutMs` | `8000` | Per-attempt timeout for the DAP `evaluate` call. Increase for big object graphs. |
 | `csharpDebugCopyAsJson.preferNewtonsoft` | `false` | Try `Newtonsoft.Json` before `System.Text.Json`. Useful when your project's serialization rules are Newtonsoft-flavored. |
-| `csharpDebugCopyAsJson.trace` | `false` | Write expression / DAP / fallback diagnostics to the **Copy as JSON** output channel. Off by default to avoid persisting variable values to logs. |
+| `csharpDebugCopyAsJson.trace` | `false` | Write expression / DAP / fallback / cache-hit diagnostics to the **Copy as JSON** output channel. Off by default to avoid persisting variable values to logs. |
+| `csharpDebugCopyAsJson.showSideEffectReminder` | `true` | Show a transient status-bar reminder on every invocation that the command evaluates expressions in the debuggee process. Set to `false` once you are familiar with the behavior. The one-time output-channel disclosure is unaffected. |
 
 ## Limitations
 
@@ -45,6 +48,8 @@ The first time you use the command in a workspace you will see a one-time inform
 - **Synthesized debugger nodes** like `[Raw View]` and `Static members` cannot be evaluated by name and will produce a clear error.
 - **Truncation.** The .NET adapter may still cap very long strings even with `clipboard` evaluate context. If you hit a limit, increase `csharpDebugCopyAsJson.evaluateTimeoutMs` and/or restructure the variable being serialized.
 - **One session at a time.** If the active debug session changes between right-clicking and the command running, the extension aborts safely with a message.
+- **Cancelled evaluates still run in the debuggee.** When you click the command twice in quick succession the second click cancels the first inside the extension, but the underlying DAP `evaluate` request cannot be aborted &mdash; the debugger still completes the cancelled call. Side effects from the cancelled invocation can still occur even though only one result reaches the clipboard.
+- **Cache is best-effort within a paused frame.** The frame-scoped result cache assumes the variable's serialized form is stable while the frame is paused. Evaluating side-effecting expressions elsewhere (Debug Console, Watch view) between two **Copy as JSON** clicks on the same frame can return stale JSON from the cache.
 
 ## Troubleshooting
 

--- a/docs/pbi-011-realtime-cache.md
+++ b/docs/pbi-011-realtime-cache.md
@@ -1,0 +1,85 @@
+# PBI-011: Real-time Copy as JSON — frame-scoped cache, cancelable dispatch, non-blocking side-effect notice
+
+## Status
+
+Proposed. Triggered by user-reported "already running" lock-up after a successful copy followed by an unrelated clipboard write, plus a request for instant-feel re-copy on the same paused frame. Inserts ahead of PBI-006 (which remains paused on `main`). Implementation of C2 forces a one-minor-version bump of the engine floor from `^1.89.0` to `^1.90.0`; see the corresponding decision row below.
+
+## Goal
+
+Make Copy as JSON behave like a clipboard operation, not a debug operation, on the warm path. Eliminate the "already running" failure mode entirely. Preserve correctness — never serve stale JSON across a step or session boundary.
+
+## Scope
+
+In:
+
+- **C1 / Frame-scoped result cache.** Cache key `(sessionId, threadId, frameId, resolvedExpression)` → JSON string. Cache hit writes to clipboard with no DAP round-trip. In-memory, session-lifetime, no TTL, no size cap.
+- **C2 / Cache invalidation.** Subscribe to `vscode.debug.onDidChangeActiveStackItem` and `vscode.debug.onDidTerminateDebugSession`. On stack-item change, clear entries for that `(sessionId, threadId)`. On session terminate, clear all entries for that `sessionId`. No invalidation on breakpoint mutation (we never read by breakpoint id).
+- **C3 / Cancelable dispatch.** Replace the `inFlight` boolean with a per-extension `CancellationTokenSource`. A new invocation calls `.cancel()` on the previous and overwrites it. The in-flight `customRequest` is wrapped in `Promise.race` against the token; on cancel we abandon the response. Last click wins the clipboard. The DAP `evaluate` itself cannot be aborted — the debugger still runs the cancelled call to completion in the debuggee, but the extension ignores the result.
+- **C4 / Winning-context memoization.** Per `sessionId`: remember the first context (`clipboard | hover | repl`) that returned a parseable result. Subsequent invocations in the same session try that context first; only on failure do they fall through the rest of the chain. Cleared on `onDidTerminateDebugSession`.
+- **C5 / Non-blocking side-effect notice.**
+  - **C5a.** One-time `OutputChannel.appendLine` disclosure on first invocation per install, gated by the existing `csharpDebugCopyAsJson.sideEffectWarningShown` `globalState` key. Replaces the modal-ish `showInformationMessage` dialog.
+  - **C5b.** Per-invocation transient status-bar reminder `$(info) Copy as JSON: evaluating in debuggee process` for ~3 s. Suppressed when the new setting `csharpDebugCopyAsJson.showSideEffectReminder` is `false`. Default `true`.
+- **C6 / Status-bar feedback on dispatch.** On every invocation, immediately show `$(sync~spin) Copy as JSON…` in the status bar. Cleared on success, cache hit, failure, or cancel.
+
+Out:
+
+- Pre-warm on variable hover / expand. Conflicts with the side-effect contract — would issue evaluates the user never asked for.
+- Cross-session persistent cache. DAP `frameId` is session-scoped; nothing transferable.
+- Cache invalidation on watch-expression evaluation. Best-effort within a paused frame, accepted by user.
+- Real cancellation of the DAP `evaluate` request. VS Code does not propagate cancellation to debug adapters.
+- Removing the side-effect notice entirely. The disclosure is preserved (output channel + status bar) — only the modality is removed.
+
+## Architectural decisions
+
+| Decision | Reasoning |
+|---|---|
+| Cache key includes `threadId` | DAP `frameId` is unique only per thread per session. Multi-threaded debuggees would otherwise collide. |
+| Invalidate on `onDidChangeActiveStackItem`, not on `continued`/`stopped` DAP events | Single source of truth. Stepping fires this event. Switching frames in the Call Stack view also fires it (correctly invalidates because the user is now looking at a different frame). User confirmed this stricter rule (Call Stack frame switch should invalidate). |
+| Cancel-and-replace, not concurrent or queued | Two parallel evaluates would double the side effects in the debuggee, which is exactly what users were warned about. Cancel keeps a single live response in flight at the extension layer. |
+| Winning-context memo per session, not global | `supportsClipboardContext` is per-session; preference can flip between a `coreclr` session and a hypothetical `mono` session. |
+| In-memory cache, no eviction | A typical debug session pauses tens of times, not thousands. Each entry is one JSON string. Memory growth is bounded by user attention span. |
+| Side-effect notice via output channel + status bar, not dialog | User explicitly requested non-blocking. Disclosure preserved; user agency over flow restored. |
+| Drop `inFlight` boolean entirely | The cancellation-token model subsumes its job. Keeping both would be two locks racing each other. |
+| `showSideEffectReminder` setting, default `true` | Power users who already understand the side-effect contract can mute the per-invocation reminder; default keeps disclosure visible. |
+| Bump `engines.vscode` floor from `^1.89.0` to `^1.90.0` | `vscode.debug.onDidChangeActiveStackItem` (used by C2) and `vscode.debug.activeStackItem` (used by the pre-existing PBI-004 capture path) only graduated from the `debugFocus` proposal in VS Code 1.90.0 (microsoft/vscode#212190, May 2024). Subscribing at activation on 1.89.x throws and the extension fails to load — caught by the PBI-005 activation-smoke test on its first run against the floor. PBI-001 mistakenly advertised `^1.89.0` as the floor: the API was *proposed* in 1.89, not stable. PBI-011 is the first feature to surface the bug because C2 subscribes at activation time; PBI-004's lazy property reads would only have thrown at command-invocation time. This bump fixes today's regression and the latent 0.1.x risk in a single change; `VSCODE_TEST_VERSION` in `ci.yml`/`release.yml` and `DEFAULT_VSCODE_VERSION` in `runIntegration.ts` are bumped in lockstep so CI's smoke gate keeps proving the floor. |
+
+## UX notes
+
+- Status-bar messages, in order across an invocation:
+  - Immediate: `$(sync~spin) Copy as JSON…`.
+  - On cache hit: `$(check) Copied N chars as JSON (cached)` for 4 s.
+  - On evaluate success: `$(check) Copied N chars as JSON via <serializer>` for 4 s.
+  - On failure or cancel: spin cleared; error toast surfaces as today (cancel is silent — no toast).
+- Cache hits issue zero debug-adapter requests. Verifiable via `csharpDebugCopyAsJson.trace: true` (logs `cache hit: <expression>` instead of `evaluate (...)`).
+- The C5b reminder fires on every click while `showSideEffectReminder` is `true`. Cheap, non-blocking, keeps disclosure in front of the user. Mutable.
+- C5a output-channel disclosure runs once per install (existing `globalState` key reused — upgrading users who already dismissed the dialog will not see the disclosure again).
+
+## Acceptance criteria
+
+1. Click Copy as JSON, do not paste, copy unrelated text, click Copy as JSON again on the same paused variable → clipboard now contains the JSON. No "already running" toast, ever, under any sequence of clicks.
+2. With `trace: true`, the second click in (1) emits `cache hit:` and *no* `evaluate (...)` line.
+3. Step over → click Copy as JSON on the same variable → emits `evaluate (...)`, not a cache hit. (Cache invalidated on step.)
+4. Switch to a different frame in the Call Stack view → click Copy as JSON on a variable that was previously cached on the current frame → re-evaluates (Call Stack frame switch invalidates).
+5. Click Copy as JSON twice within 100 ms → only one final clipboard write occurs (the second click cancels the first). Trace shows two `evaluate (...)` lines and one `cancelled` line.
+6. First-ever invocation on a fresh install: no modal-ish dialog. Output channel contains the one-time disclosure note. Status bar briefly shows the per-invocation reminder.
+7. Setting `showSideEffectReminder: false` → no per-invocation reminder; output-channel disclosure still fires once on first invocation.
+8. Session ends and a new debug session starts → cache is cold; first invocation re-evaluates.
+9. Existing PBI-002, -003, -004 unit tests pass without modification.
+10. `npm run test:integration` against the bumped floor (1.90.0) activates cleanly. Activation-smoke output contains no `CANNOT use API proposal: debugFocus` line. (Engine-floor honor check, paired with the corresponding decision-table row.)
+
+## UAT checklist
+
+| # | Scenario | Expected result |
+|---|---|---|
+| 1 | Copy a variable. Copy unrelated text from elsewhere. Copy the same variable again. | Second copy is instant; clipboard has the JSON; no toast. |
+| 2 | Step over. Copy same variable. | Re-evaluates (visible in trace as a fresh `evaluate (...)` line). |
+| 3 | Spam-click the same variable's menu 5 times. | Exactly one clipboard write completes; clipboard contains the latest variable's JSON; trace shows cancellations. |
+| 4 | Fresh install: first Copy as JSON invocation. | No info dialog. Output channel has a one-line disclosure. Status bar flashes reminder. |
+| 5 | Set `showSideEffectReminder` to `false`. Trigger Copy as JSON. | No status-bar reminder. Output-channel disclosure still appears once on first ever invocation. |
+| 6 | End session, restart debugger, copy same variable name on first hit. | Re-evaluates (cache is session-scoped). |
+| 7 | Pause at frame A, copy `parent.child`. Click frame B in Call Stack, copy `local`. Click frame A again, copy `parent.child`. | Step 3 re-evaluates because Call Stack frame switching invalidates the entry. |
+| 8 | Pause at frame A, copy `parent.child`. Copy `parent`. | Both hit the adapter (different expressions); both subsequently cached. |
+
+## Telemetry
+
+None.

--- a/docs/pbi-012-buffer-deprecation.md
+++ b/docs/pbi-012-buffer-deprecation.md
@@ -1,0 +1,114 @@
+# PBI-012 — Trace and silence DEP0005 `Buffer()` deprecation in the e2e test host
+
+Status: Proposed
+Filed: 2026-04-27 (during PBI-011 implementation)
+
+## Problem
+
+When running the integration suite with `RUN_E2E=1` against stable VS Code
+(observed on 1.117.0) with the `ms-dotnettools.csharp` extension installed,
+the extension host prints once at startup:
+
+```
+(node:10894) [DEP0005] DeprecationWarning: Buffer() is deprecated due to
+security and usability issues. Please use the Buffer.alloc(),
+Buffer.allocUnsafe(), or Buffer.from() methods instead.
+(Use `Code Helper (Plugin) --trace-deprecation ...` to show where the
+warning was created)
+```
+
+The warning is benign today but `DEP0005` is on Node's roadmap to become a
+hard error in a future major. When it flips, the test host (and every
+end-user host on the same Node) will fail to start.
+
+## What is NOT the source (already ruled out, 2026-04-27)
+
+- **Our `src/`**: `rg "new Buffer\\("` across `src/` returns no matches.
+- **VS Code 1.90.0** (the new engine floor after PBI-011): activation smoke
+  ran with `NODE_OPTIONS='--trace-deprecation'` and emitted **no** DEP0005.
+  So the offender is something present in newer VS Code or in the loaded
+  C# extension chain, but not in 1.90.
+
+## Likely sources (to confirm in PBI-012 spike)
+
+In order of decreasing probability based on what differs between the 1.90
+activation-smoke run and the 1.117 e2e run:
+
+1. **`ms-dotnettools.csharp` itself** (or one of its bundled JS deps:
+   Roslyn LSP client, debugger glue, `vscode-languageclient`, etc.).
+2. **`ms-dotnettools.vscode-dotnet-runtime`**, which is auto-pulled by the
+   C# extension.
+3. **VS Code 1.117 internals** — possible but unlikely; Microsoft's own
+   lint catches `new Buffer()` in core.
+4. **A devDependency of ours that loads only in the e2e harness path**
+   (e.g. something inside `@vscode/test-electron`'s extension-host
+   bootstrap) — also unlikely; the warning fires *inside* the host
+   process, not the runner.
+
+## Goals
+
+- (G1) Identify the exact offender with a stack trace.
+- (G2) If the offender is ours, fix it by replacing `new Buffer(...)` with
+  `Buffer.from / Buffer.alloc / Buffer.allocUnsafe`.
+- (G3) If the offender is upstream, file an issue on the offending repo
+  and link it from this PBI. **Do not** patch or vendor the offender.
+- (G4) Make `--trace-deprecation` permanent for the e2e harness so the
+  next deprecation does not require this investigation re-work.
+
+## Out of scope
+
+- Suppressing `DEP0005` globally via `--no-deprecation`. We want to know
+  when it changes status.
+- Rewriting unrelated `Buffer()` usages in `node_modules/` (transitive
+  deps that happen to also use it but did not trigger this warning).
+
+## Architectural decisions
+
+- Add `NODE_OPTIONS=--trace-deprecation` (or the per-process equivalent)
+  to the `extensionTestsEnv` in `runE2e()` permanently. The activation
+  smoke path can stay clean since it does not currently reproduce.
+- Capture the trace from a clean `RUN_E2E=1` run, identify the topmost
+  user-or-extension frame, and decide G2 vs. G3 from that frame.
+- If G3: the upstream issue link goes in the **Status** header of this
+  doc (e.g. `Status: Filed upstream — microsoft/vscode-csharp#NNNN`),
+  and we add a Mocha output filter so the warning does not pollute CI
+  logs while we wait for the upstream fix. The filter must match
+  precisely the DEP0005 line so it cannot mask a different deprecation.
+
+## Acceptance criteria
+
+- [ ] AC1 — A `RUN_E2E=1` run on the same VS Code/C#-extension versions
+      where the warning was originally observed produces a stack trace
+      that names the offending file or extension. Trace pasted into this
+      doc as evidence.
+- [ ] AC2 — Either:
+      (a) the offender is in our code or our direct deps and is fixed
+          (warning gone), OR
+      (b) an upstream issue is linked from the **Status** header and
+          the warning is suppressed in CI output by a precise Mocha
+          reporter filter (with comment justifying scope).
+- [ ] AC3 — `runIntegration.ts` permanently passes `--trace-deprecation`
+      to the e2e extension host so a future deprecation does not require
+      a separate spike.
+
+## UAT checklist
+
+- [ ] `RUN_E2E=1 npm run test:integration` produces no `DEP0005` line in
+      stdout.
+- [ ] If suppression is in place rather than a real fix, manually
+      verify that flipping the suppression off still prints exactly the
+      one expected warning, and that an unrelated injected
+      `process.emitWarning('test', 'DeprecationWarning')` is NOT
+      suppressed.
+
+## Telemetry
+
+None.
+
+## References
+
+- DEP0005 (Buffer constructor): https://nodejs.org/api/deprecations.html#DEP0005
+- Original repro: terminals/1.txt:998-1001 (RUN_E2E=1 run on 2026-04-27).
+- Negative result on 1.90 activation smoke: this branch's
+  `npm run test:integration` with `NODE_OPTIONS='--trace-deprecation'`
+  on 2026-04-27 — no DEP0005 emitted.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "vscode-csharp-copy-as-json",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-csharp-copy-as-json",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/mocha": "^10.0.6",
         "@types/node": "^25.6.0",
-        "@types/vscode": "^1.89.0",
+        "@types/vscode": "^1.90.0",
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "@vscode/debugprotocol": "^1.66.0",
@@ -24,7 +24,7 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24",
-        "vscode": "^1.89.0"
+        "vscode": "^1.90.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-csharp-copy-as-json",
   "displayName": "Copy as JSON (C# Debug)",
   "description": "Right-click a variable in the VS Code Variables view during a C#/.NET debug session and copy it to the clipboard as pretty-printed JSON.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "JadeEye21",
   "license": "MIT",
   "author": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/JadeEye21/vscode-csharp-copy-as-json#readme",
   "qna": "https://github.com/JadeEye21/vscode-csharp-copy-as-json/issues",
   "engines": {
-    "vscode": "^1.89.0",
+    "vscode": "^1.90.0",
     "node": "^20.19.0 || ^22.13.0 || >=24"
   },
   "categories": [
@@ -85,7 +85,12 @@
         "csharpDebugCopyAsJson.trace": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "When `true`, write timestamped diagnostic logs (expression sent, DAP response shape, fallback decisions) to the **Copy as JSON** output channel. Off by default to avoid persisting potentially sensitive variable values to logs."
+          "markdownDescription": "When `true`, write timestamped diagnostic logs (expression sent, DAP response shape, fallback decisions, cache hits) to the **Copy as JSON** output channel. Off by default to avoid persisting potentially sensitive variable values to logs."
+        },
+        "csharpDebugCopyAsJson.showSideEffectReminder": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "When `true`, show a transient status-bar reminder on every invocation that **Copy as JSON** evaluates expressions inside the debuggee process (which invokes property getters and constructors, with potential side effects). Set to `false` once you are familiar with the behavior. The disclosure is also written once per install to the **Copy as JSON** output channel regardless of this setting."
         }
       }
     }
@@ -105,7 +110,7 @@
     "@eslint/js": "^10.0.1",
     "@types/mocha": "^10.0.6",
     "@types/node": "^25.6.0",
-    "@types/vscode": "^1.89.0",
+    "@types/vscode": "^1.90.0",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "@vscode/debugprotocol": "^1.66.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { unescapeCsharpString } from './util/unescape.js';
 import { validateEvaluateResult } from './util/validate.js';
 import { withTimeout } from './util/withTimeout.js';
 import {
-  clearSession,
+  clearSession as clearCapabilitySession,
   createCapabilityTracker,
   getSupportsClipboardContext,
 } from './util/clipboardCapability.js';
@@ -21,6 +21,7 @@ import {
   type CapturedFrame,
   type CurrentSnapshot,
 } from './util/frameStability.js';
+import { ResultCache } from './util/resultCache.js';
 
 const COMMAND_ID = 'csharpDebugCopyAsJson.copyAsJson';
 const CONFIG_SECTION = 'csharpDebugCopyAsJson';
@@ -34,42 +35,52 @@ interface DapEvaluateResponse {
   variablesReference?: number;
 }
 
-let inFlight = false;
 let output: vscode.OutputChannel | undefined;
-// Test-only file sink. When set (only happens under CSHARP_COPY_AS_JSON_E2E),
-// every trace() and showError() line is also appended here so the e2e test can
-// read it deterministically. We use sync fs.appendFileSync because:
-//   (a) lines are tiny (one log line per call);
-//   (b) we MUST avoid interleaved writes between the trace() that records the
-//       evaluate failure and the showError() that records the user-facing
-//       message -- async fs would let the showError write race ahead.
-// In production this stays undefined and writeE2eLog is a no-op.
+// Test-only file sink. See PBI-005 / PBI-010 for why this exists.
 let e2eLogFile: string | undefined;
+
+// PBI-011 module-level state ------------------------------------------------
+//
+// `currentCts` is the cancellation source for the in-flight `runCopyAsJson`
+// invocation. A second click cancels and disposes the previous source before
+// installing a new one. `Promise.race`-style cancellation on the awaits
+// alone is not enough; every await checks `token.isCancellationRequested`
+// before performing side effects (clipboard write, cache put), because the
+// underlying DAP `customRequest` cannot itself be aborted.
+let currentCts: vscode.CancellationTokenSource | undefined;
+
+// `lastActiveStackItem` tracks the previously-focused frame so that
+// `onDidChangeActiveStackItem` can invalidate that thread's cache entries.
+// We invalidate both the previous thread AND the new thread on every
+// change; this is intentionally over-eager (per the PBI-011 "stricter"
+// invalidation rule confirmed by the user), and never serves stale data.
+let lastActiveStackItem: { sessionId: string; threadId: number } | undefined;
+
+const resultCache = new ResultCache();
+
+// Memo of the first DAP `evaluate` context that returned a parseable result
+// for a session. On subsequent invocations in the same session we try this
+// context first before falling through the rest of the chain. Cleared on
+// session terminate.
+const winningContext = new Map<string, EvaluateContext>();
+// ---------------------------------------------------------------------------
 
 export function activate(context: vscode.ExtensionContext): void {
   output = vscode.window.createOutputChannel('Copy as JSON');
   context.subscriptions.push(output);
 
   // Test-only seam: when our e2e harness sets CSHARP_COPY_AS_JSON_E2E=1 in
-  // extensionTestsEnv, pre-seed the "first-run side-effect warning" flag so
-  // the modal does not block automation, and open a file-backed log sink in
-  // the workspace root so the test can read every trace/error line back. We
-  // use the env var (not a hidden command) because a registered command would
-  // otherwise leak into the user command palette. The check runs once at
-  // activation; no behavior change in production builds because no user sets
-  // this variable.
+  // extensionTestsEnv, pre-seed the disclosure-shown flag so the one-time
+  // output-channel notice does not pollute the test log, and open a
+  // file-backed sink in the workspace root.
   if (process.env.CSHARP_COPY_AS_JSON_E2E === '1') {
     void context.globalState.update(SIDE_EFFECT_WARNING_KEY, true);
     const wsFolder = vscode.workspace.workspaceFolders?.[0];
     if (wsFolder) {
       e2eLogFile = path.join(wsFolder.uri.fsPath, 'test.trace.log');
       try {
-        // Truncate any leftover log from a previous run so we never
-        // confuse "this run produced no log" with "previous run's log".
         fs.writeFileSync(e2eLogFile, '');
       } catch {
-        // If we cannot create the file we silently fall back to no-sink;
-        // worst case the test sees the same opaque failure as before.
         e2eLogFile = undefined;
       }
     }
@@ -80,12 +91,7 @@ export function activate(context: vscode.ExtensionContext): void {
       runCopyAsJson(arg, context),
     ),
   );
-  // Watch every debug session's InitializeResponse so we know, authoritatively,
-  // whether the adapter supports DAP `evaluate` with `context: 'clipboard'`.
-  // Registered for `'*'` rather than `coreclr`/`clr` because the user can
-  // override `csharpDebugCopyAsJson.allowedDebugTypes`; the cost of a no-op
-  // tracker on unrelated sessions (one closure, one event subscription) is
-  // negligible compared to silently demoting the user to `hover`.
+
   context.subscriptions.push(
     vscode.debug.registerDebugAdapterTrackerFactory('*', {
       createDebugAdapterTracker(session) {
@@ -93,9 +99,34 @@ export function activate(context: vscode.ExtensionContext): void {
       },
     }),
   );
+
+  // PBI-011 / C2: result-cache invalidation. `onDidChangeActiveStackItem`
+  // fires for stepping, continuing, and Call-Stack-view frame switching;
+  // all three cases need the cache eviction (per AC #4).
+  context.subscriptions.push(
+    vscode.debug.onDidChangeActiveStackItem(() => {
+      const previous = lastActiveStackItem;
+      if (previous) {
+        resultCache.clearThread(previous.sessionId, previous.threadId);
+      }
+      const stackItem = vscode.debug.activeStackItem;
+      if (stackItem instanceof vscode.DebugStackFrame) {
+        resultCache.clearThread(stackItem.session.id, stackItem.threadId);
+        lastActiveStackItem = {
+          sessionId: stackItem.session.id,
+          threadId: stackItem.threadId,
+        };
+      } else {
+        lastActiveStackItem = undefined;
+      }
+    }),
+  );
+
   context.subscriptions.push(
     vscode.debug.onDidTerminateDebugSession((session) => {
-      clearSession(session.id);
+      clearCapabilitySession(session.id);
+      resultCache.clearSession(session.id);
+      winningContext.delete(session.id);
     }),
   );
 }
@@ -103,32 +134,45 @@ export function activate(context: vscode.ExtensionContext): void {
 export function deactivate(): void {
   output = undefined;
   e2eLogFile = undefined;
-  inFlight = false;
+  if (currentCts) {
+    currentCts.cancel();
+    currentCts.dispose();
+    currentCts = undefined;
+  }
+  resultCache.clearAll();
+  winningContext.clear();
+  lastActiveStackItem = undefined;
 }
 
-async function runCopyAsJson(arg: IVariablesContext, context: vscode.ExtensionContext): Promise<void> {
-  if (inFlight) {
-    void vscode.window.showInformationMessage(
-      'Copy as JSON is already running for the previous variable. Wait for it to finish.',
-    );
-    return;
+async function runCopyAsJson(
+  arg: IVariablesContext,
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  // PBI-011 / C3: cancel-and-replace dispatch. The previous in-flight
+  // invocation is cancelled and disposed; its DAP `evaluate` call may still
+  // execute in the debuggee (we cannot abort that), but the extension will
+  // ignore its response.
+  if (currentCts) {
+    currentCts.cancel();
+    currentCts.dispose();
   }
-  inFlight = true;
+  const cts = new vscode.CancellationTokenSource();
+  currentCts = cts;
   try {
-    await runCopyAsJsonInner(arg, context);
+    await runCopyAsJsonInner(arg, context, cts.token);
   } finally {
-    inFlight = false;
+    if (currentCts === cts) {
+      currentCts = undefined;
+    }
+    cts.dispose();
   }
 }
 
 async function runCopyAsJsonInner(
   arg: IVariablesContext,
   context: vscode.ExtensionContext,
+  token: vscode.CancellationToken,
 ): Promise<void> {
-  // ------------------------------------------------------------------
-  // Pre-warning gates: synchronous, no awaits, so the user cannot step
-  // between these checks and the error toasts.
-  // ------------------------------------------------------------------
   const initialSession = vscode.debug.activeDebugSession;
   if (!initialSession) {
     showError('No active debug session.');
@@ -145,23 +189,18 @@ async function runCopyAsJsonInner(
   }
 
   if (arg && arg.sessionId && initialSession.id !== arg.sessionId) {
-    // Menu invocation arg disagrees with the now-active session: focus moved
-    // between the right-click and the command callback.
     showError(SESSION_MOVED_MESSAGE);
     return;
   }
 
-  // Existence check (not capture). If the user invoked from the command
-  // palette without pausing, surface the friendly "you forgot to pause"
-  // message here, before the side-effect warning ever appears.
-  const preCheckFrame = vscode.debug.activeStackItem;
-  if (!preCheckFrame || !(preCheckFrame instanceof vscode.DebugStackFrame)) {
+  const stackItem = vscode.debug.activeStackItem;
+  if (!stackItem || !(stackItem instanceof vscode.DebugStackFrame)) {
     showError(
       'No focused stack frame. Pause the debugger and select a frame in the Call Stack view, then try again.',
     );
     return;
   }
-  if (preCheckFrame.session.id !== initialSession.id) {
+  if (stackItem.session.id !== initialSession.id) {
     showError(SESSION_MOVED_MESSAGE);
     return;
   }
@@ -172,153 +211,187 @@ async function runCopyAsJsonInner(
     return;
   }
 
-  // ------------------------------------------------------------------
-  // Side-effect warning (PBI-001) is shown here -- BEFORE we capture the
-  // frame id. On the first-ever invocation this is an await boundary the
-  // user can step over; capturing the frame after the dialog dismisses is
-  // what closes review item C2 (PBI-004). On every subsequent invocation
-  // the warning is a no-op (globalState says "shown"), so this re-ordering
-  // does not affect the steady-state flow.
-  // ------------------------------------------------------------------
-  await maybeShowSideEffectWarning(context);
+  const captured: CapturedFrame = {
+    sessionId: initialSession.id,
+    frameId: stackItem.frameId,
+    threadId: stackItem.threadId,
+  };
 
   const traceEnabled = cfg.get<boolean>('trace', false);
 
-  // Re-capture after the warning. If the user clicked Continue or Step
-  // during the dialog, the frame is now gone or different and we abort
-  // with the canonical "session moved" message instead of letting an
-  // adapter-level "stale frame" error reach the user.
-  const captured = captureFrame(initialSession.id);
-  if (!captured.ok) {
-    trace(traceEnabled, `post-warning capture failed: ${captured.reason}`);
-    showError(captured.reason);
+  // PBI-011 / C1: cache lookup. A hit short-circuits the entire DAP path.
+  const cached = resultCache.get(
+    captured.sessionId,
+    captured.threadId,
+    captured.frameId,
+    target.expression,
+  );
+  if (cached !== undefined) {
+    if (token.isCancellationRequested) {
+      return;
+    }
+    await vscode.env.clipboard.writeText(cached);
+    if (token.isCancellationRequested) {
+      return;
+    }
+    trace(
+      traceEnabled,
+      `cache hit: ${target.expression} (${cached.length} chars)`,
+    );
+    void vscode.window.setStatusBarMessage(
+      `$(check) Copied ${cached.length} chars as JSON (cached)`,
+      4000,
+    );
     return;
   }
-  trace(
-    traceEnabled,
-    `captured frame: sessionId=${captured.frame.sessionId}, frameId=${captured.frame.frameId}, threadId=${captured.frame.threadId}`,
+
+  // ----- Cache miss: evaluate path -----
+
+  // PBI-011 / C5a: one-time output-channel disclosure on first invocation
+  // per install. Replaces the previous modal-ish info-message dialog. The
+  // existing `SIDE_EFFECT_WARNING_KEY` is reused so users who already
+  // dismissed the old dialog do not see the disclosure again.
+  maybeShowOneTimeDisclosure(context);
+
+  // PBI-011 / C5b: per-invocation transient reminder. Suppressed when the
+  // user has set `showSideEffectReminder: false`.
+  const showReminder = cfg.get<boolean>('showSideEffectReminder', true);
+  if (showReminder) {
+    void vscode.window.setStatusBarMessage(
+      '$(info) Copy as JSON: evaluating in debuggee process',
+      3000,
+    );
+  }
+
+  // PBI-011 / C6: dispatch spinner. Disposed in the `finally` so cancel,
+  // failure, and success all clear the spin promptly.
+  const spinDisposable = vscode.window.setStatusBarMessage(
+    '$(sync~spin) Copy as JSON\u2026',
   );
 
-  const timeoutMs = clampTimeout(cfg.get<number>('evaluateTimeoutMs', 8000));
-  const preferNewtonsoft = cfg.get<boolean>('preferNewtonsoft', false);
+  try {
+    const timeoutMs = clampTimeout(cfg.get<number>('evaluateTimeoutMs', 8000));
+    const preferNewtonsoft = cfg.get<boolean>('preferNewtonsoft', false);
 
-  const stjExpr = buildSystemTextJsonExpression(target.expression);
-  const newtonExpr = buildNewtonsoftExpression(target.expression);
-  const ordered = preferNewtonsoft
-    ? [
-        { label: 'Newtonsoft.Json', expression: newtonExpr },
-        { label: 'System.Text.Json', expression: stjExpr },
-      ]
-    : [
-        { label: 'System.Text.Json', expression: stjExpr },
-        { label: 'Newtonsoft.Json', expression: newtonExpr },
-      ];
+    const stjExpr = buildSystemTextJsonExpression(target.expression);
+    const newtonExpr = buildNewtonsoftExpression(target.expression);
+    const ordered = preferNewtonsoft
+      ? [
+          { label: 'Newtonsoft.Json', expression: newtonExpr },
+          { label: 'System.Text.Json', expression: stjExpr },
+        ]
+      : [
+          { label: 'System.Text.Json', expression: stjExpr },
+          { label: 'Newtonsoft.Json', expression: newtonExpr },
+        ];
 
-  const contexts = pickEvaluateContexts(initialSession);
-  trace(traceEnabled, `target = ${target.expression}`);
-  trace(traceEnabled, `evaluate contexts = ${contexts.join(', ')}`);
+    // PBI-011 / C4: try the per-session winning context first.
+    const baseContexts = pickEvaluateContexts(initialSession);
+    const memo = winningContext.get(initialSession.id);
+    const contexts: EvaluateContext[] =
+      memo && baseContexts.includes(memo)
+        ? [memo, ...baseContexts.filter((c) => c !== memo)]
+        : baseContexts;
 
-  let lastError: string | undefined;
-  for (const attempt of ordered) {
-    for (const evalContext of contexts) {
-      // Re-validate before EVERY evaluate: each prior await (the previous
-      // attempt's customRequest, or the warning) is a step opportunity.
-      const stability = checkFrameStability(captured.frame, snapshotCurrent());
-      if (!stability.ok) {
-        trace(traceEnabled, `frame stability check failed: ${stability.reason}`);
-        showError(stability.reason);
-        return;
-      }
-      trace(
-        traceEnabled,
-        `re-validated frame: sessionId=${captured.frame.sessionId}, frameId=${captured.frame.frameId}`,
-      );
+    trace(traceEnabled, `target = ${target.expression}`);
+    trace(traceEnabled, `evaluate contexts = ${contexts.join(', ')}`);
 
-      const contextLabel = `${attempt.label} (${evalContext})`;
-      trace(
-        traceEnabled,
-        `evaluate (${contextLabel}): ${attempt.expression}`,
-      );
-      try {
-        const resp = await withTimeout(
-          initialSession.customRequest('evaluate', {
-            expression: attempt.expression,
-            frameId: captured.frame.frameId,
-            context: evalContext,
-          }) as Thenable<DapEvaluateResponse>,
-          timeoutMs,
-          `${contextLabel} evaluate`,
-        );
-        const validation = validateEvaluateResult(
-          resp?.result,
-          unescapeCsharpString,
-          contextLabel,
-        );
-        if (validation.ok) {
-          await vscode.env.clipboard.writeText(validation.json);
-          trace(
-            traceEnabled,
-            `success: copied ${validation.json.length} chars to clipboard via ${contextLabel}`,
-          );
-          void vscode.window.setStatusBarMessage(
-            `$(clippy) Copied ${validation.json.length} chars as JSON via ${attempt.label}`,
-            4000,
-          );
+    let lastError: string | undefined;
+    for (const attempt of ordered) {
+      for (const evalContext of contexts) {
+        if (token.isCancellationRequested) {
+          trace(traceEnabled, 'cancelled');
           return;
         }
-        lastError = validation.reason;
+        const stability = checkFrameStability(captured, snapshotCurrent());
+        if (!stability.ok) {
+          trace(
+            traceEnabled,
+            `frame stability check failed: ${stability.reason}`,
+          );
+          showError(stability.reason);
+          return;
+        }
+        const contextLabel = `${attempt.label} (${evalContext})`;
         trace(
           traceEnabled,
-          `validation failed: ${validation.reason}; raw=${JSON.stringify(resp)}`,
+          `evaluate (${contextLabel}): ${attempt.expression}`,
         );
-      } catch (err) {
-        lastError = errorMessage(err);
-        trace(traceEnabled, `error: ${lastError}`);
+        try {
+          const resp = await withTimeout(
+            initialSession.customRequest('evaluate', {
+              expression: attempt.expression,
+              frameId: captured.frameId,
+              context: evalContext,
+            }) as Thenable<DapEvaluateResponse>,
+            timeoutMs,
+            `${contextLabel} evaluate`,
+          );
+          if (token.isCancellationRequested) {
+            trace(traceEnabled, 'cancelled after evaluate');
+            return;
+          }
+          const validation = validateEvaluateResult(
+            resp?.result,
+            unescapeCsharpString,
+            contextLabel,
+          );
+          if (validation.ok) {
+            if (token.isCancellationRequested) {
+              trace(traceEnabled, 'cancelled before clipboard write');
+              return;
+            }
+            await vscode.env.clipboard.writeText(validation.json);
+            // Re-check after the clipboard write: a later click may have
+            // already overwritten our value, in which case we must NOT
+            // poison the cache with the stale entry. We still leave the
+            // clipboard alone -- the later click wrote intentionally.
+            if (token.isCancellationRequested) {
+              trace(
+                traceEnabled,
+                'cancelled after clipboard write; not caching',
+              );
+              return;
+            }
+            resultCache.put(
+              captured.sessionId,
+              captured.threadId,
+              captured.frameId,
+              target.expression,
+              validation.json,
+            );
+            winningContext.set(initialSession.id, evalContext);
+            trace(
+              traceEnabled,
+              `success: copied ${validation.json.length} chars to clipboard via ${contextLabel}`,
+            );
+            void vscode.window.setStatusBarMessage(
+              `$(check) Copied ${validation.json.length} chars as JSON via ${attempt.label}`,
+              4000,
+            );
+            return;
+          }
+          lastError = validation.reason;
+          trace(
+            traceEnabled,
+            `validation failed: ${validation.reason}; raw=${JSON.stringify(resp)}`,
+          );
+        } catch (err) {
+          lastError = errorMessage(err);
+          trace(traceEnabled, `error: ${lastError}`);
+        }
       }
     }
-  }
 
-  showError(`Could not serialize: ${lastError ?? 'unknown error'}`);
+    if (token.isCancellationRequested) {
+      return;
+    }
+    showError(`Could not serialize: ${lastError ?? 'unknown error'}`);
+  } finally {
+    spinDisposable.dispose();
+  }
 }
 
-/**
- * Read the live `vscode.debug` state and return the focused frame iff it
- * still belongs to `expectedSessionId`. Used immediately after the
- * side-effect warning to detect a Continue/Step that fired while the dialog
- * was open (PBI-004 / review item C2).
- */
-function captureFrame(
-  expectedSessionId: string,
-):
-  | { ok: true; frame: CapturedFrame }
-  | { ok: false; reason: string } {
-  const session = vscode.debug.activeDebugSession;
-  if (!session || session.id !== expectedSessionId) {
-    return { ok: false, reason: SESSION_MOVED_MESSAGE };
-  }
-  const stackItem = vscode.debug.activeStackItem;
-  if (
-    !stackItem ||
-    !(stackItem instanceof vscode.DebugStackFrame) ||
-    stackItem.session.id !== expectedSessionId
-  ) {
-    return { ok: false, reason: SESSION_MOVED_MESSAGE };
-  }
-  return {
-    ok: true,
-    frame: {
-      sessionId: expectedSessionId,
-      frameId: stackItem.frameId,
-      threadId: stackItem.threadId,
-    },
-  };
-}
-
-/**
- * Snapshot the live `vscode.debug` state into the shape `checkFrameStability`
- * expects. Kept tiny and side-effect-free so that the per-attempt re-check
- * loop adds negligible cost on the happy path.
- */
 function snapshotCurrent(): CurrentSnapshot {
   const session = vscode.debug.activeDebugSession;
   const stackItem = vscode.debug.activeStackItem;
@@ -337,11 +410,7 @@ function snapshotCurrent(): CurrentSnapshot {
 
 function pickEvaluateContexts(session: vscode.DebugSession): EvaluateContext[] {
   // The cache is populated by the DebugAdapterTracker we register in
-  // `activate`. A cache miss means we never observed an InitializeResponse for
-  // this session - either the tracker was registered too late (impossible
-  // given `onDebug` activation) or the adapter never sent capabilities. The
-  // safe default is `false`: skip `clipboard` and use `hover -> repl`, which
-  // is what every adapter is required to support.
+  // `activate`. A cache miss means we never observed an InitializeResponse.
   const supports = getSupportsClipboardContext(session.id) === true;
   return supports ? ['clipboard', 'hover', 'repl'] : ['hover', 'repl'];
 }
@@ -367,9 +436,6 @@ function errorMessage(err: unknown): string {
 
 function trace(enabled: boolean, message: string): void {
   const ts = new Date().toISOString();
-  // Always mirror to the e2e file sink (regardless of the user's `trace`
-  // setting) so the test sees every step. In production e2eLogFile is
-  // undefined and writeE2eLog is a no-op.
   writeE2eLog(`[${ts}] ${message}`);
   if (!enabled || !output) {
     return;
@@ -378,10 +444,6 @@ function trace(enabled: boolean, message: string): void {
 }
 
 function showError(message: string): void {
-  // Mirror EVERY user-facing error to the e2e file sink, even when the
-  // user's trace setting is off. This is the line that tells the test why
-  // the command bailed (e.g. the actual evaluator error from STJ /
-  // Newtonsoft) when there is no clipboard write to inspect.
   writeE2eLog(`[ERROR] ${message}`);
   void vscode.window
     .showErrorMessage(`Copy as JSON: ${message}`, 'View Logs')
@@ -399,23 +461,25 @@ function writeE2eLog(line: string): void {
   try {
     fs.appendFileSync(e2eLogFile, line + '\n');
   } catch {
-    // Sink failures must never fail the user's command. The test will see a
-    // shorter log than expected and surface that itself.
+    // Sink failures must never fail the user's command.
   }
 }
 
-async function maybeShowSideEffectWarning(context: vscode.ExtensionContext): Promise<void> {
-  const shown = context.globalState.get<boolean>(SIDE_EFFECT_WARNING_KEY, false);
+function maybeShowOneTimeDisclosure(context: vscode.ExtensionContext): void {
+  const shown = context.globalState.get<boolean>(
+    SIDE_EFFECT_WARNING_KEY,
+    false,
+  );
   if (shown) {
     return;
   }
-  const choice = await vscode.window.showInformationMessage(
-    "Copy as JSON evaluates 'JsonSerializer.Serialize' inside your debugged process. " +
-      'This invokes property getters and constructors, which may have side effects, allocate memory, or throw.',
-    'Got it',
-    "Don't show again",
-  );
-  if (choice === "Don't show again" || choice === 'Got it') {
-    await context.globalState.update(SIDE_EFFECT_WARNING_KEY, true);
+  if (output) {
+    output.appendLine(
+      '[disclosure] Copy as JSON evaluates JsonSerializer.Serialize inside ' +
+        'your debugged process. This invokes property getters and ' +
+        'constructors, which may have side effects, allocate memory, or ' +
+        'throw. See README for details. (Shown once per install.)',
+    );
   }
+  void context.globalState.update(SIDE_EFFECT_WARNING_KEY, true);
 }

--- a/src/test/integration/copyAsJson.e2e.test.ts
+++ b/src/test/integration/copyAsJson.e2e.test.ts
@@ -251,10 +251,45 @@ suite("e2e copy-as-json against real coreclr debugger", function () {
     await fs.writeFile(clipboardDumpAbs, clipboardText, "utf8");
     console.log(`[e2e] wrote clipboard payload to ${clipboardDumpAbs}`);
 
+    // -----------------------------------------------------------------
+    // PBI-011 / C1 + C2: second click on the same paused frame MUST be
+    // served from the frame-scoped result cache, not by issuing a second
+    // DAP evaluate. This is the regression test for the user-reported
+    // "Copy as JSON is already running for the previous variable" lock-up:
+    // after a successful copy, copying unrelated text (here we overwrite
+    // the clipboard with a fresh sentinel) and re-invoking the command on
+    // the same variable must restore the JSON instantly with no toast and
+    // no second adapter round-trip.
+    // -----------------------------------------------------------------
+    const SECOND_SENTINEL = "<sentinel: second click did not write>";
+    await vscode.env.clipboard.writeText(SECOND_SENTINEL);
+
+    await vscode.commands.executeCommand(COMMAND_ID, personArg);
+
+    const secondClipboardText = await waitForClipboardChange(
+      SECOND_SENTINEL,
+      CLIPBOARD_WAIT_MS,
+    );
+    if (secondClipboardText === SECOND_SENTINEL) {
+      const failTrace = await readTraceLog(traceLogAbs);
+      assert.fail(
+        `second click did not write to the clipboard within ${CLIPBOARD_WAIT_MS}ms; ` +
+          `the PBI-011 cache-hit path is broken (or the second invocation was ` +
+          `silently refused). Trace log (${traceLogAbs}):\n${failTrace}`,
+      );
+    }
+    assert.equal(
+      secondClipboardText,
+      clipboardText,
+      "second click on the same paused variable should write byte-for-byte " +
+        "the same JSON as the first click (served from the result cache)",
+    );
+
     // Capture the trace log NOW, while it's small and easy to attribute to
     // this command invocation. Reading after termination would still work
     // (the file persists), but capturing here keeps the assertion below
-    // attached to a single, unambiguous slice of the log.
+    // attached to a single, unambiguous slice of the log -- BOTH the first
+    // (real evaluate) and the second (cache hit) clicks above.
     const traceText = await readTraceLog(traceLogAbs);
 
     // -----------------------------------------------------------------
@@ -490,6 +525,43 @@ suite("e2e copy-as-json against real coreclr debugger", function () {
     assert.ok(
       !/^\[ERROR\]/m.test(traceText),
       `trace contains [ERROR] line -- command surfaced an error to the user:\n${traceText}`,
+    );
+
+    // -----------------------------------------------------------------
+    // PBI-011 cache-hit assertions on the SAME captured trace slice.
+    // The first click logged `evaluate (...)`; the second click MUST log
+    // `cache hit:` and MUST NOT log a second `evaluate (...)`.
+    // -----------------------------------------------------------------
+
+    assert.match(
+      traceText,
+      /cache hit: person /,
+      `expected a 'cache hit: person ...' line from the second click; ` +
+        `the cache-hit path did not fire. Trace:\n${traceText}`,
+    );
+
+    // Exactly ONE `evaluate (` line across both clicks. If we see two, the
+    // cache miss path ran on the second click -- meaning the lookup failed
+    // (key derivation regression) or invalidation fired prematurely.
+    const evaluateLineCount = (
+      traceText.match(/^\[[^\]]+\] evaluate \(/gm) ?? []
+    ).length;
+    assert.equal(
+      evaluateLineCount,
+      1,
+      `expected exactly 1 'evaluate (' line across both clicks (first hits ` +
+        `the adapter, second is a cache hit); got ${evaluateLineCount}. ` +
+        `Full trace:\n${traceText}`,
+    );
+
+    // The 'cancelled' code paths should NOT fire on a clean two-click flow
+    // where the first click fully resolved before the second started. If
+    // we see this line the cancel-and-replace dispatch is firing when it
+    // shouldn't (e.g. the previous CTS was not cleared in the finally).
+    assert.ok(
+      !/^\[[^\]]+\] cancelled/m.test(traceText),
+      `trace contains a 'cancelled' line -- the second click was treated as ` +
+        `a cancel-replace of the first, not as a fresh invocation. Trace:\n${traceText}`,
     );
   });
 });

--- a/src/test/integration/runIntegration.ts
+++ b/src/test/integration/runIntegration.ts
@@ -9,7 +9,14 @@ import {
 // Pin to our engines.vscode floor so a passing CI run proves the
 // minimum-supported promise still holds. Override with VSCODE_TEST_VERSION
 // (e.g. "stable" or "insiders") for ad-hoc runs against newer builds.
-const DEFAULT_VSCODE_VERSION = "1.89.0";
+//
+// 1.90.0 is the floor because PBI-011 / C2 subscribes to
+// `vscode.debug.onDidChangeActiveStackItem` at activation time, and that API
+// (along with `vscode.debug.activeStackItem`, used since PBI-004) graduated
+// from the `debugFocus` proposal to stable in VS Code 1.90.0
+// (microsoft/vscode#212190, May 2024 milestone). On 1.89.x the activation
+// throws because the host blocks unapproved use of proposed APIs.
+const DEFAULT_VSCODE_VERSION = "1.90.0";
 
 // E2E mode: honor RUN_E2E=1 to exercise the real coreclr debugger against
 // the test-fixtures/csharp-sample project. This requires a different VS Code

--- a/src/test/resultCache.test.ts
+++ b/src/test/resultCache.test.ts
@@ -1,0 +1,109 @@
+import { strict as assert } from 'node:assert';
+import { ResultCache } from '../util/resultCache.js';
+
+suite('ResultCache', () => {
+  test('get returns undefined on miss', () => {
+    const c = new ResultCache();
+    assert.equal(c.get('s', 1, 1, 'x'), undefined);
+  });
+
+  test('put then get round-trips', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'person.Age', '{"v":42}');
+    assert.equal(c.get('s', 1, 100, 'person.Age'), '{"v":42}');
+  });
+
+  test('different frameId is a miss', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'x', 'a');
+    assert.equal(c.get('s', 1, 101, 'x'), undefined);
+  });
+
+  test('different threadId is a miss', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'x', 'a');
+    assert.equal(c.get('s', 2, 100, 'x'), undefined);
+  });
+
+  test('different sessionId is a miss', () => {
+    const c = new ResultCache();
+    c.put('s1', 1, 100, 'x', 'a');
+    assert.equal(c.get('s2', 1, 100, 'x'), undefined);
+  });
+
+  test('different expression is a miss', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'a', 'A');
+    c.put('s', 1, 100, 'b', 'B');
+    assert.equal(c.get('s', 1, 100, 'a'), 'A');
+    assert.equal(c.get('s', 1, 100, 'b'), 'B');
+  });
+
+  test('clearThread evicts only that thread', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'x', 'thread1');
+    c.put('s', 2, 100, 'x', 'thread2');
+    c.clearThread('s', 1);
+    assert.equal(c.get('s', 1, 100, 'x'), undefined);
+    assert.equal(c.get('s', 2, 100, 'x'), 'thread2');
+  });
+
+  test('clearThread evicts all frames within the thread', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'x', 'a');
+    c.put('s', 1, 101, 'x', 'b');
+    c.put('s', 1, 102, 'x', 'c');
+    c.clearThread('s', 1);
+    assert.equal(c.size(), 0);
+  });
+
+  test('clearSession evicts only that session', () => {
+    const c = new ResultCache();
+    c.put('s1', 1, 100, 'x', 'A');
+    c.put('s2', 1, 100, 'x', 'B');
+    c.clearSession('s1');
+    assert.equal(c.get('s1', 1, 100, 'x'), undefined);
+    assert.equal(c.get('s2', 1, 100, 'x'), 'B');
+  });
+
+  test('clearSession evicts across threads and frames', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'x', 'a');
+    c.put('s', 1, 101, 'y', 'b');
+    c.put('s', 2, 100, 'z', 'c');
+    c.clearSession('s');
+    assert.equal(c.size(), 0);
+  });
+
+  test('clearAll empties the cache', () => {
+    const c = new ResultCache();
+    c.put('s1', 1, 1, 'x', 'A');
+    c.put('s2', 2, 2, 'y', 'B');
+    c.clearAll();
+    assert.equal(c.size(), 0);
+  });
+
+  test('keys with overlapping numeric prefixes do not collide', () => {
+    // Without a delimiter, threadId=1 + frameId=23 could collide with
+    // threadId=12 + frameId=3. The NUL separator prevents this.
+    const c = new ResultCache();
+    c.put('s', 1, 23, 'x', 'A');
+    c.put('s', 12, 3, 'x', 'B');
+    assert.equal(c.get('s', 1, 23, 'x'), 'A');
+    assert.equal(c.get('s', 12, 3, 'x'), 'B');
+  });
+
+  test('expressions containing dots and brackets round-trip', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'arr[0].Inner.Field', 'A');
+    assert.equal(c.get('s', 1, 100, 'arr[0].Inner.Field'), 'A');
+  });
+
+  test('put overwrites previous value for same key', () => {
+    const c = new ResultCache();
+    c.put('s', 1, 100, 'x', 'old');
+    c.put('s', 1, 100, 'x', 'new');
+    assert.equal(c.get('s', 1, 100, 'x'), 'new');
+    assert.equal(c.size(), 1);
+  });
+});

--- a/src/util/resultCache.ts
+++ b/src/util/resultCache.ts
@@ -1,0 +1,87 @@
+/**
+ * Frame-scoped cache of serialized JSON results (PBI-011).
+ *
+ * Key shape: `(sessionId, threadId, frameId, expression)`. We collapse it
+ * into a single string with `\u0000` as the field separator because:
+ *   - DAP `sessionId`s and the C# expressions we resolve via
+ *     `resolveEvaluatableTarget` cannot contain a NUL byte (the latter come
+ *     from the .NET adapter's `evaluateName`/`name` fields, both UTF-8 source
+ *     identifiers);
+ *   - `Map<string, string>` lookups are O(1) and avoid the allocation cost
+ *     of a nested-Map structure.
+ *
+ * Lifecycle is managed by `extension.ts`: on `onDidChangeActiveStackItem`
+ * we evict per-thread, on `onDidTerminateDebugSession` we evict per-session.
+ *
+ * Intentionally module-free of `vscode` so it can be unit-tested without
+ * an Electron host.
+ */
+export class ResultCache {
+  private readonly entries = new Map<string, string>();
+
+  put(
+    sessionId: string,
+    threadId: number,
+    frameId: number,
+    expression: string,
+    json: string,
+  ): void {
+    this.entries.set(toKey(sessionId, threadId, frameId, expression), json);
+  }
+
+  get(
+    sessionId: string,
+    threadId: number,
+    frameId: number,
+    expression: string,
+  ): string | undefined {
+    return this.entries.get(toKey(sessionId, threadId, frameId, expression));
+  }
+
+  /**
+   * Drop every entry belonging to `(sessionId, threadId)`. Called when the
+   * active stack item changes inside that thread (step, continue, or
+   * Call-Stack-view frame switch). Per the PBI-011 spec we evict eagerly
+   * rather than try to detect "same thread, different frameId" because the
+   * test surface stays smaller and a redundant evict never serves stale
+   * data.
+   */
+  clearThread(sessionId: string, threadId: number): void {
+    const prefix = `${sessionId}\u0000${threadId}\u0000`;
+    for (const k of this.entries.keys()) {
+      if (k.startsWith(prefix)) {
+        this.entries.delete(k);
+      }
+    }
+  }
+
+  /**
+   * Drop every entry belonging to `sessionId`. Called on
+   * `onDidTerminateDebugSession`.
+   */
+  clearSession(sessionId: string): void {
+    const prefix = `${sessionId}\u0000`;
+    for (const k of this.entries.keys()) {
+      if (k.startsWith(prefix)) {
+        this.entries.delete(k);
+      }
+    }
+  }
+
+  clearAll(): void {
+    this.entries.clear();
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}
+
+function toKey(
+  sessionId: string,
+  threadId: number,
+  frameId: number,
+  expression: string,
+): string {
+  return `${sessionId}\u0000${threadId}\u0000${frameId}\u0000${expression}`;
+}


### PR DESCRIPTION
## Summary

- **PBI-011 — Real-time Copy as JSON.** Re-copying the same variable on the same paused frame is now served from an in-memory cache keyed by `(sessionId, threadId, frameId, expression)` — no DAP round-trip, no extra side effects in the debuggee. The "Copy as JSON is already running for the previous variable" toast is gone; a new invocation cancels the previous via `CancellationTokenSource` and last click wins the clipboard. The first-use modal side-effect dialog is replaced by a one-time output-channel disclosure plus a per-invocation status-bar reminder gated by the new `csharpDebugCopyAsJson.showSideEffectReminder` setting (default `true`).
- **BREAKING CHANGE — engine floor `^1.89.0` → `^1.90.0`.** `vscode.debug.onDidChangeActiveStackItem` (used by C2) and `vscode.debug.activeStackItem` (used since PBI-004) only graduated from the `debugFocus` proposal in VS Code 1.90.0 (microsoft/vscode#212190, May 2024). Subscribing on 1.89.x throws at activation. PBI-001 mistakenly advertised `^1.89.0` as the floor — the API was *proposed* in 1.89, not stable — so this bump also closes a latent 0.1.x risk where invoking Copy as JSON on a 1.89.x host would have thrown at command-time. `VSCODE_TEST_VERSION` (in `ci.yml` / `release.yml`) and `DEFAULT_VSCODE_VERSION` (in `runIntegration.ts`) are bumped in lockstep so CI's smoke gate keeps proving the floor.
- **PBI-012 filed (Proposed).** `docs/pbi-012-buffer-deprecation.md` captures the DEP0005 `Buffer()` warning observed once at startup during `RUN_E2E=1` runs against stable VS Code 1.117 + `ms-dotnettools.csharp`. Not reproducible on the 1.90 activation-smoke path with `--trace-deprecation`, so the source is upstream; deferred to a separate spike.

## Implementation map

| ID | Concern | Location |
|---|---|---|
| C1 | Cache class + 13 unit tests | `src/util/resultCache.ts`, `src/test/resultCache.test.ts` |
| C2 | Cache invalidation on stack-item change & session terminate | `src/extension.ts` (`activate`) |
| C3 | Cancel-and-replace via per-extension `CancellationTokenSource`; post-await guard before clipboard write & before cache put | `src/extension.ts` (`runCopyAsJson`, `runCopyAsJsonInner`) |
| C4 | Per-session winning-context memo (`clipboard \| hover \| repl`) | `src/extension.ts` |
| C5 | One-time output-channel disclosure (gated by existing `sideEffectWarningShown` `globalState` key) + per-invocation transient status-bar reminder | `src/extension.ts`, new setting in `package.json` |
| C6 | `$(sync~spin) Copy as JSON…` on dispatch; distinct success messages so cache hits are observable in the status bar | `src/extension.ts` |

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run compile` — clean.
- [x] `npm run test:unit` — **84/84 passing** (13 new `ResultCache` tests).
- [x] `npm run test:integration` against the bumped floor (1.90.0) — activation smoke **2/2 passing**, no `CANNOT use API proposal: debugFocus` line. AC #10 satisfied.
- [x] `RUN_E2E=1 npm run test:integration` against stable VS Code 1.117 with `ms-dotnettools.csharp` — **3/3 passing** (activation smoke + real-coreclr-debugger end-to-end). The new cache-hit assertions verify: (a) clipboard re-fills on the second click, (b) trace contains exactly one `evaluate (` line across both invocations, (c) no `cancelled` line. AC #1, #2 satisfied via real debugger.
- [ ] **Manual UAT (reviewer / author, on a fresh VS Code 1.90+ install)** — covers the AC items not feasible to automate:
  - [ ] AC #3 — Step over → re-evaluate (no cache hit) on the same variable.
  - [ ] AC #4 — Switch to a different frame in Call Stack view → re-evaluate.
  - [ ] AC #5 — Spam-click the same variable five times within 100 ms → exactly one final clipboard write; trace shows multiple `cancelled` lines.
  - [ ] AC #6 — First-ever invocation on a fresh install → no modal dialog; output channel has the one-line disclosure; status-bar reminder flashes.
  - [ ] AC #7 — `showSideEffectReminder: false` → no per-invocation reminder; one-time output-channel disclosure still fires once.
  - [ ] AC #8 — Session ends, restart debug → cache cold; first invocation re-evaluates.

## Risk surface

- **Engine floor users on 1.89.x.** They lose the extension on upgrade. Mitigation: 1.90.0 is 22 months old (May 2024); upgrade path is straightforward; called out under `### Breaking` in `CHANGELOG.md`.
- **DAP `evaluate` side-effect cancellation is best-effort.** A cancelled invocation still runs to completion in the debuggee — VS Code does not propagate cancellation to debug adapters. Documented as an explicit Out-of-scope item in `docs/pbi-011-realtime-cache.md` and reiterated in README's Limitations section.
- **Cache memory unbounded.** Intentional — typical session pauses tens of times, not thousands; entries are JSON strings; `onDidTerminateDebugSession` is a hard reset. If this proves wrong in practice, a small LRU is a one-PBI follow-up.

## Release flow after merge

1. Squash-merge **disabled** (project convention is `--no-ff` merge commits per `.cursor/rules/agent-mode.mdc`). Use the **Create a merge commit** option.
2. After merge to `main`: `git tag v0.2.0 <merge-sha> && git push origin v0.2.0` — this triggers `release.yml` which builds the VSIX, runs the activation smoke (now against 1.90.0), and uploads the artifact to GitHub Releases.
3. PBI-012 backlog item stays Proposed until you decide to schedule the spike.

## Linked artifacts

- PBI doc: `docs/pbi-011-realtime-cache.md`
- Backlog filed: `docs/pbi-012-buffer-deprecation.md`
- Upstream API graduation: microsoft/vscode#212190