### PR TITLE
docs(pbi): reconcile Status headers with what shipped (#24)

### DIFF
--- a/docs/pbi-001-copy-as-json.md
+++ b/docs/pbi-001-copy-as-json.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented in `v0.0.1`. Awaiting UAT.
+**Completed in v0.0.1.**
 
 ## Goal
 

--- a/docs/pbi-002-validate-evaluate-result.md
+++ b/docs/pbi-002-validate-evaluate-result.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**In progress.** Branch `feature/pbi-002-validate-evaluate-result` extracts validation into pure modules, wires them into `extension.ts`, and adds unit tests covering C1 (truncation rejection) and R5 (looksLikeError regressions). R1 (repl-context echo stripping) is **explicitly deferred** - see "Deviations from plan" below.
+**Completed (partial) in v0.1.0.** Validation extracted into pure modules, wired into `extension.ts`, and unit-tested for C1 (truncation rejection) and R5 (`looksLikeError` regressions). R1 (repl-context echo stripping) is **explicitly deferred** — see "Deviations from plan" below.
 
 ## Goal
 

--- a/docs/pbi-003-stable-capability-detection.md
+++ b/docs/pbi-003-stable-capability-detection.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**In progress.** Production code and unit tests delivered on `feature/pbi-003-stable-capability-detection`.
+**Completed in v0.1.0.**
 
 | Phase | Items | Status |
 |---|---|---|

--- a/docs/pbi-004-frame-stability-across-dialogs.md
+++ b/docs/pbi-004-frame-stability-across-dialogs.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**In progress.** Production code and unit tests delivered on `feature/pbi-004-frame-stability`.
+**Completed in v0.1.0.** Note: PBI-011 / C5 removed the post-side-effect-warning re-capture step (the modal warning is gone in v0.2.0); `checkFrameStability` from this PBI still runs per evaluate attempt and is unchanged.
 
 | Phase | Items | Status |
 |---|---|---|

--- a/docs/pbi-005-activation-integration-tests.md
+++ b/docs/pbi-005-activation-integration-tests.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**In progress.** Phase 1 (harness + activation smoke) is delivered by branch `feature/pbi-005-test-electron-harness`. Phase 2 items below are deferred and will be picked up alongside the PBIs that consume them.
+**Completed (partial).** Phase 1 (harness + activation smoke) shipped in v0.1.0. Phase 2 fake-DAP coverage remains deferred — tracked in [#25](https://github.com/JadeEye21/vscode-csharp-copy-as-json/issues/25) and will be picked up alongside the PBIs that consume it.
 
 | Phase | Items | Status |
 |---|---|---|

--- a/docs/pbi-007-workflow-supply-chain-hardening.md
+++ b/docs/pbi-007-workflow-supply-chain-hardening.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed. Derived from code review of `v0.0.1` (W1, W2, W4, R6).
+**Completed in v0.1.0–v0.1.1.** Groundwork shipped in v0.1.0 (lockfile, Dependabot for npm + GitHub Actions, `npm install --omit=optional` in workflows, batch dependency upgrades, `.vscodeignore` for leaner VSIX, Node 24 for first-party Actions, `test:unit`-only release jobs). Real-VS-Code activation-smoke gate added to `release.yml` in v0.1.1 so a build that fails to activate can no longer reach a GitHub Release.
 
 ## Goal
 

--- a/docs/pbi-010-real-debugger-e2e.md
+++ b/docs/pbi-010-real-debugger-e2e.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**In progress.** Production code and local-only e2e harness delivered on `feature/pbi-010-real-debugger-e2e`.
+**Completed in v0.1.0.** Opt-in real-debugger E2E harness (`RUN_E2E=1`) with C# sample fixture, clipboard JSON assertions, and trace mirroring for diagnostics. Local-only by design; not gated in CI.
 
 | Phase | Items | Status |
 |---|---|---|

--- a/docs/pbi-011-realtime-cache.md
+++ b/docs/pbi-011-realtime-cache.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed. Triggered by user-reported "already running" lock-up after a successful copy followed by an unrelated clipboard write, plus a request for instant-feel re-copy on the same paused frame. Inserts ahead of PBI-006 (which remains paused on `main`). Implementation of C2 forces a one-minor-version bump of the engine floor from `^1.89.0` to `^1.90.0`; see the corresponding decision row below.
+**Completed in v0.2.0.** Triggered by user-reported "already running" lock-up after a successful copy followed by an unrelated clipboard write, plus a request for instant-feel re-copy on the same paused frame. Shipped C1–C6 as scoped; C2 forced a one-minor-version bump of the engine floor from `^1.89.0` to `^1.90.0` — see the corresponding decision row below.
 
 ## Goal
 


### PR DESCRIPTION
Eight PBI docs carried stale `Status:` headers ("Proposed" / "In progress") even though the work has been on `main` and released for one or more versions. CHANGELOG.md is the truth-of-record for shipped behavior; the doc Status lines should mirror it, not diverge. Today's drift made docs unreliable for backlog audits — this commit eliminates the drift in one pass.

Mappings (CHANGELOG.md → doc):

- PBI-001 → "Completed in v0.0.1." (initial release)
- PBI-002 → "Completed (partial) in v0.1.0." R1 repl-context echo stripping remains explicitly deferred.
- PBI-003 → "Completed in v0.1.0."
- PBI-004 → "Completed in v0.1.0." Note that PBI-011 / C5 removed the post-side-effect-warning re-capture step in v0.2.0 (the warning is gone); `checkFrameStability` from PBI-004 still runs per evaluate attempt and is unchanged.
- PBI-005 → "Completed (partial). Phase 1 in v0.1.0; Phase 2 fake-DAP coverage tracked in #25."
- PBI-007 → "Completed in v0.1.0–v0.1.1." Groundwork in 0.1.0; real-VS- Code activation-smoke gate added to release.yml in 0.1.1.
- PBI-010 → "Completed in v0.1.0."
- PBI-011 → "Completed in v0.2.0." Plus the engine-floor-bump callout.

Out of scope (intentional):
- PBI-006 / PBI-008 / PBI-009 docs — work is genuinely open (#18, #19, #20); Status stays "Proposed".
- PBI-012 doc — already correct (just created).
- No CHANGELOG edits, no code changes, no decision-table or AC edits.

Diff is exactly +1/-1 per file; only line 5 of each `## Status` block moves. `npm run lint && npm run compile && npm run test:unit` pass unchanged (84/84).

Closes #24

## Summary

<!-- 1-3 bullets explaining the change. -->

## Test plan

- [ ] `npm run lint`
- [ ] `npm run compile`
- [ ] `npm test`
- [ ] Manual: launched Extension Development Host against `samples/dotnet-console` and exercised the affected code path.

## Linked issues

Closes #
